### PR TITLE
Adding build_date arg.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ RUN npm ci
 COPY . .
 
 FROM base AS build
+ARG BUILD_DATE
 ENV NODE_ENV=production
 ENV NEXT_PUBLIC_BUILD_DATE=$BUILD_DATE
+RUN echo $NEXT_PUBLIC_BUILD_DATE
 WORKDIR /build
 COPY --from=base /base ./
 RUN npm run build


### PR DESCRIPTION
I think the build time for the last date modified did not work because I forgot to define it in our Dockerfile as an ARG.