### PR TITLE
Removing the custom test.

### DIFF
--- a/components/atoms/ActionButton.test.js
+++ b/components/atoms/ActionButton.test.js
@@ -23,7 +23,6 @@ describe('ActionButton', () => {
       <ActionButton
         id="testID"
         data-testid="testId"
-        custom
         className="bg-red-400 text-white border"
       />
     )


### PR DESCRIPTION
Quick remove of the `custom` keyword for testing the ActionButton.