### PR TITLE
apiData renamed to data

### DIFF
--- a/pages/home.js
+++ b/pages/home.js
@@ -102,7 +102,7 @@ export async function getStaticProps({ locale }) {
 
   let AEMbenefits = await aemService.getFragment('benefits.json')
   errorCode = AEMbenefits.error
-  if (AEMbenefits.apiData && !errorCode) {
+  if (AEMbenefits.data && !errorCode) {
     benefits = AEMbenefits.data.entities
   }
 


### PR DESCRIPTION
Fixed bug where API data was renamed to data causing Most Requested Pages to not show
