### PR TITLE
Cleaned up Adobe Analytics code

### DIFF
--- a/components/atoms/Meta.js
+++ b/components/atoms/Meta.js
@@ -8,14 +8,6 @@ export default function Meta({ title, keywords, description, lang }) {
       <meta name="keywords" content={keywords} />
       <meta name="description" content={description} />
       <meta name="robots" content="noindex,nofollow" />
-      <meta name="dcterms.title" content="Home Page" />
-      <meta name="dcterms.language" content={lang == 'en' ? 'eng' : 'fra'} />
-      <meta
-        name="dcterms.creator"
-        content="Employment and Social Development Canada/Emploi et Développement social Canada"
-      />
-      <meta name="dcterms.accessRights" content="2" />
-      <meta name="dcterms.service" content="ESDC-EDSC_DC-CD" />
       <meta charSet="utf-8" />
       <link rel="icon" href="/favicon.ico" />
       <title>{title}</title>

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -17,7 +17,17 @@ export default function Layout({ children, locale, title, phase, bannerText }) {
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
-      window.adobeDataLayer.push({ event: 'pageLoad' })
+      window.adobeDataLayer.push({
+        event: 'pageLoad',
+        page: {
+          title: document.title,
+          language: locale === 'en' ? 'eng' : 'fra',
+          creator:
+            'Employment and Social Development Canada/Emploi et Développement social Canada',
+          accessRights: '2',
+          service: 'ESDC-EDSC_DC-CD',
+        },
+      })
     }
   }, [])
 

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -4,6 +4,7 @@ import Meta from '../atoms/Meta'
 import PhaseBanner from '../atoms/PhaseBanner'
 import Header from '../molecules/Header'
 import Footer from '../molecules/Footer'
+import { useEffect } from 'react'
 
 import en from '../../locales/en'
 import fr from '../../locales/fr'
@@ -13,6 +14,12 @@ import fr from '../../locales/fr'
  */
 export default function Layout({ children, locale, title, phase, bannerText }) {
   const t = locale === 'en' ? en : fr
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer.push({ event: 'pageLoad' })
+    }
+  }, [])
 
   return (
     <div>


### PR DESCRIPTION
### Description
Moved meta data to push of analytics for more control
Analytics beacon should fire every time layout is rendered

### What to test for/How to test
Adobe Analytics group will have to test post PR merge

### Notes
Zain will be moving Layout to _app.js ensuring it gets rendered on each page