### PR TITLE
added image priority to imagebox component

### DIFF
--- a/components/organisms/ImageBox.js
+++ b/components/organisms/ImageBox.js
@@ -21,6 +21,7 @@ export default function ImageBox(props) {
             layout={props.layout}
             objectFit={props.objectFit}
             objectPosition={props.objectPosition}
+            priority={props.priority}
           />
         </div>
       </div>
@@ -43,6 +44,9 @@ ImageBox.propTypes = {
   objectFit: PropTypes.string,
   // image objectPosition
   objectPosition: PropTypes.string,
+  // image priority - if the image is above the fold set to true otherwise it should be false
+  // more info here https://nextjs.org/docs/api-reference/next/image#priority
+  priority: PropTypes.bool,
 
   // other elements you want to add
   children: PropTypes.oneOfType([

--- a/pages/home.js
+++ b/pages/home.js
@@ -27,6 +27,7 @@ export default function Home(props) {
         layout="fill"
         objectFit="cover"
         objectPosition="20% 80%"
+        priority={true}
       >
         <SearchCard
           lang={props.locale}


### PR DESCRIPTION
## [DCWC-841](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-841) (Jira Issue)

### Description
Added a bool property for priority to the next/image so that it preloads the image if that image is above the fold. 

more info here. 
https://nextjs.org/docs/api-reference/next/image#priority

### What to test for/How to test

### Additional Notes
