### PR TITLE
DCWC-797

### DIFF
--- a/__tests__/pages/home.test.js
+++ b/__tests__/pages/home.test.js
@@ -32,6 +32,23 @@ jest.mock(
 
 expect.extend(toHaveNoViolations)
 
+const aemPage = {
+  title: {
+    en: 'Home (en)',
+    fr: 'Home (fr)',
+  },
+  meta: {
+    keywords: {
+      en: 'en keywords',
+      fr: 'fr keywords',
+    },
+    description: {
+      en: 'en description',
+      fr: 'fr description',
+    },
+  },
+}
+
 describe('Home page', () => {
   const featured = {
     scTitleEn: { value: 'title' },
@@ -122,6 +139,7 @@ describe('Home page', () => {
         topTasks={topTasks}
         topTaskTitle={topTaskTitle}
         searchPageHref={searchPageHref}
+        aemPage={aemPage}
       />
     )
     const enLink = screen.getByText('English')
@@ -137,6 +155,7 @@ describe('Home page', () => {
         topTasks={topTasks}
         topTaskTitle={topTaskTitle}
         searchPageHref={searchPageHref}
+        aemPage={aemPage}
       />
     )
     const enLink = screen.getByText('Français')
@@ -151,6 +170,7 @@ describe('Home page', () => {
         topTasks={topTasks}
         topTaskTitle={topTaskTitle}
         searchPageHref={searchPageHref}
+        aemPage={aemPage}
       />
     )
     expect(screen.getByTestId('searchCard')).toBeTruthy()
@@ -164,6 +184,7 @@ describe('Home page', () => {
         topTasks={topTasks}
         topTaskTitle={topTaskTitle}
         searchPageHref={searchPageHref}
+        aemPage={aemPage}
       />
     )
     expect(screen.getByTestId('serviceCanada')).toBeTruthy()
@@ -177,6 +198,7 @@ describe('Home page', () => {
         topTasks={topTasks}
         topTaskTitle={topTaskTitle}
         searchPageHref={searchPageHref}
+        aemPage={aemPage}
       />
     )
     expect(screen.getByTestId('topTasks')).toBeTruthy()
@@ -190,6 +212,7 @@ describe('Home page', () => {
         topTasks={topTasks}
         topTaskTitle={topTaskTitle}
         searchPageHref={searchPageHref}
+        aemPage={aemPage}
       />
     )
     expect(screen.getByTestId('cardList')).toBeTruthy()
@@ -203,6 +226,7 @@ describe('Home page', () => {
         topTasks={topTasks}
         topTaskTitle={topTaskTitle}
         searchPageHref={searchPageHref}
+        aemPage={aemPage}
       />
     )
     expect(screen.getByTestId('featureBlock')).toBeTruthy()
@@ -216,6 +240,7 @@ describe('Home page', () => {
         topTasks={topTasks}
         topTaskTitle={topTaskTitle}
         searchPageHref={searchPageHref}
+        aemPage={aemPage}
       />
     )
     expect(screen.getByTestId('contactUs')).toBeTruthy()
@@ -229,6 +254,7 @@ describe('Home page', () => {
         topTasks={topTasks}
         topTaskTitle={topTaskTitle}
         searchPageHref={searchPageHref}
+        aemPage={aemPage}
       />
     )
     const results = await axe(container)

--- a/__tests__/pages/search.test.js
+++ b/__tests__/pages/search.test.js
@@ -20,6 +20,23 @@ jest.mock('next/link', () => ({
 
 expect.extend(toHaveNoViolations)
 
+const aemPage = {
+  title: {
+    en: 'Search (en)',
+    fr: 'Search (fr)',
+  },
+  meta: {
+    keywords: {
+      en: 'en keywords',
+      fr: 'fr keywords',
+    },
+    description: {
+      en: 'en description',
+      fr: 'fr description',
+    },
+  },
+}
+
 describe('Search page', () => {
   const searchPageHref = {
     en: '/search',
@@ -78,7 +95,12 @@ describe('Search page', () => {
   })
   it('should render in French', () => {
     render(
-      <Search locale="fr" benefits={benefits} searchPageHref={searchPageHref} />
+      <Search
+        locale="fr"
+        benefits={benefits}
+        searchPageHref={searchPageHref}
+        aemPage={aemPage}
+      />
     )
     const enLink = screen.getByText('English')
     expect(enLink).toBeInTheDocument()
@@ -86,7 +108,12 @@ describe('Search page', () => {
 
   it('should render in English', () => {
     render(
-      <Search locale="en" benefits={benefits} searchPageHref={searchPageHref} />
+      <Search
+        locale="en"
+        benefits={benefits}
+        searchPageHref={searchPageHref}
+        aemPage={aemPage}
+      />
     )
     const enLink = screen.getByText('Français')
     expect(enLink).toBeInTheDocument()
@@ -94,7 +121,12 @@ describe('Search page', () => {
 
   it('has no a11y violations', async () => {
     const { container } = render(
-      <Search locale="en" benefits={benefits} searchPageHref={searchPageHref} />
+      <Search
+        locale="en"
+        benefits={benefits}
+        searchPageHref={searchPageHref}
+        aemPage={aemPage}
+      />
     )
     const results = await axe(container)
     expect(results).toHaveNoViolations()

--- a/__tests__/pages/splash.test.js
+++ b/__tests__/pages/splash.test.js
@@ -4,19 +4,43 @@
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Splash from '../../pages/index'
+import { useRouter } from 'next/router'
+
+// mocks useRouter to be able to use component' router.asPath
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}))
+
+const samplePage = {
+  title: {
+    en: 'Digital Centre (en) + Digital Centre (fr)',
+    fr: 'Digital Centre (en) + Digital Centre (fr)',
+  },
+  meta: {
+    keywords: {
+      en: 'en + fr keywords',
+      fr: 'en + fr keywords',
+    },
+    description: {
+      en: 'en + fr description',
+      fr: 'en + fr description',
+    },
+  },
+}
 
 describe('Splash page', () => {
+  beforeEach(() => {
+    useRouter.mockImplementation(() => ({
+      pathname: '/',
+      asPath: '/',
+      query: {
+        search: '',
+      },
+    }))
+  })
+
   it('should render', () => {
-    render(
-      <Splash
-        homePage={{
-          link: {
-            en: '/',
-            fr: '/fr/',
-          },
-        }}
-      />
-    )
+    render(<Splash locale={'en'} page={samplePage} />)
     const enLink = screen.getByText('English')
     expect(enLink).toBeInTheDocument()
   })

--- a/components/atoms/Meta.js
+++ b/components/atoms/Meta.js
@@ -1,16 +1,65 @@
 import propTypes from 'prop-types'
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 
-export default function Meta({ title, keywords, description, lang }) {
+export default function Meta({ locale, aemPage }) {
+  const title = aemPage.title[locale]
+  const currentUrl = useRouter().asPath
+  const keywords = aemPage.meta.keywords[locale]
+  const owner = aemPage.meta.owner[locale]
+  const description = aemPage.meta.description[locale]
+  const dcTerms = aemPage.meta.dcTerms
+  const audience = aemPage.meta.audience
+  const type = aemPage.meta.type
+  const img = aemPage.meta.img[locale]
+
   return (
-    <Head>
+    <Head prefix="og:http://ogp.me/ns#">
+      <title>{title} - Canada.ca</title>
+      <meta charSet="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
+      <meta name="dcterms.title" content={title} />
+      <meta name="dcterms.description" content={description} />
+      <meta name="dcterms.creator" content={owner} />
+      <meta
+        name="dcterms.language"
+        title="ISO639-2/T"
+        content={locale === 'en' ? 'eng' : 'fra'}
+      />
+      {dcTerms.map((term, i) => (
+        <meta
+          key={`dc-term-${i}`}
+          name="dcterms.subject"
+          title="gccore"
+          content={term}
+        />
+      ))}
       <meta name="keywords" content={keywords} />
       <meta name="description" content={description} />
+      <link rel="canonical" href={currentUrl} />
+      <meta name="author" content={owner} />
       <meta name="robots" content="noindex,nofollow" />
-      <meta charSet="utf-8" />
+      <meta name="dcterms.issued" title="W3CDTF" content="2017-01-23" />
+      <meta name="dcterms.audience" content={audience} />
+      <meta name="dcterms.spatial" content="Canada" />
+      <meta name="dcterms.type" content={type} />
       <link rel="icon" href="/favicon.ico" />
-      <title>{title}</title>
+      <meta name="twitter:card" content="summary_large_image" />
+      {img?.src && (
+        <>
+          <meta name="twitter:title" content={img.title} />
+          <meta name="twitter:image" content={img.src} />
+          <meta name="twitter:image:alt" content={img.alt} />
+          <meta name="twitter:description" content={img.description} />
+          <meta property="og:image" content={img.src} />
+          <meta property="og:image:alt" content={img.alt} />
+          <meta property="og:description" content={img.description} />
+        </>
+      )}
+      <meta property="og:title" content={title} />
+      <meta property="og:type" content="website" /> 
+      <meta property="og:url" content={currentUrl} />
     </Head>
   )
 }

--- a/components/atoms/Meta.js
+++ b/components/atoms/Meta.js
@@ -6,12 +6,12 @@ export default function Meta({ locale, aemPage }) {
   const title = aemPage.title[locale]
   const currentUrl = useRouter().asPath
   const keywords = aemPage.meta.keywords[locale]
-  const owner = aemPage.meta.owner[locale]
+  const owner = aemPage.meta.owner?.[locale]
   const description = aemPage.meta.description[locale]
-  const dcTerms = aemPage.meta.dcTerms
+  const dcTerms = aemPage.meta?.dcTerms || []
   const audience = aemPage.meta.audience
   const type = aemPage.meta.type
-  const img = aemPage.meta.img[locale]
+  const img = aemPage.meta.img?.[locale]
 
   return (
     <Head prefix="og:http://ogp.me/ns#">

--- a/components/atoms/Meta.test.js
+++ b/components/atoms/Meta.test.js
@@ -2,12 +2,44 @@ import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import Meta from './Meta'
+import { useRouter } from 'next/router'
+
+// mocks useRouter to be able to use component' router.asPath
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}))
 
 expect.extend(toHaveNoViolations)
 
+const samplePage = {
+  title: {
+    en: 'Digital Centre (en) + Digital Centre (fr)',
+    fr: 'Digital Centre (en) + Digital Centre (fr)',
+  },
+  meta: {
+    keywords: {
+      en: 'en + fr keywords',
+      fr: 'en + fr keywords',
+    },
+    description: {
+      en: 'en + fr description',
+      fr: 'en + fr description',
+    },
+  },
+}
+
 describe('Meta', () => {
+  beforeEach(() => {
+    useRouter.mockImplementation(() => ({
+      pathname: '/',
+      asPath: '/',
+      query: {
+        search: '',
+      },
+    }))
+  })
   it('has no a11y violations', async () => {
-    const { container } = render(<Meta title="Hello world!!" />)
+    const { container } = render(<Meta aemPage={samplePage} />)
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -41,7 +41,7 @@ export default function Layout({
 
   return (
     <div>
-      <Meta title={aemPage?.title?.[locale] || title} lang={locale} />
+      <Meta locale={locale} aemPage={aemPage} title={title} />
       <PhaseBanner
         phase={phase}
         bannerText={bannerText}

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -40,7 +40,7 @@ export default function Layout({
 
   return (
     <div>
-      <Meta locale={locale} aemPage={aemPage} title={title} />
+      <Meta locale={locale} aemPage={aemPage} />
       <PhaseBanner
         phase={phase}
         bannerText={bannerText}

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -15,7 +15,6 @@ import fr from '../../locales/fr'
 export default function Layout({
   children,
   locale,
-  title,
   phase,
   bannerText,
   aemPage,

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -3,12 +3,18 @@ import Document, { Html, Head, Main, NextScript } from 'next/document'
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const initialProps = await Document.getInitialProps(ctx)
+    this.locale = ctx.locale
     return { ...initialProps }
   }
 
   render() {
     return (
-      <Html>
+      <Html
+        className="no-js"
+        dir="ltr"
+        lang={this.locale}
+        xmlns="http://www.w3.org/1999/xhtml"
+      >
         <Head>
           {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (
             <script async src={process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL} />

--- a/pages/api/AEMServiceClass.js
+++ b/pages/api/AEMServiceClass.js
@@ -86,52 +86,7 @@ class AEMService {
   async getPage(pageId) {
     const { elements } = await this.getElements(pageId)
 
-    return {
-      id: pageId,
-      name: {
-        en: elements?.scPageNameEn?.value,
-        fr: elements?.scPageNameFr?.value,
-      },
-      link: {
-        en: `/${elements?.scPageNameEn?.value}`,
-        fr: `/fr/${elements?.scPageNameFr?.value}`,
-      },
-      title: {
-        en: elements?.scTitleEn?.value,
-        fr: elements?.scTitleFr?.value,
-      },
-      meta: {
-        keywords: {
-          en: elements?.scKeywordsEn?.value || '',
-          fr: elements?.scKeywordsFr?.value || '',
-        },
-        owner: {
-          en: elements?.scOwnerEn?.value || '',
-          fr: elements?.scOwnerFr?.value || '',
-        },
-        description: {
-          en: elements?.scDescriptionEn?.value || '',
-          fr: elements?.scDescriptionFr?.value || '',
-        },
-        dcTerms: elements?.scSubject?.value || [],
-        audience: elements?.scAudience.value || '',
-        type: elements?.scContentType.value || '',
-        img: {
-          en: {
-            src: elements?.scImageEn?.value || '',
-            title: elements?.scTitleEn?.value || '',
-            alt: elements?.scImageAltTextEn?.value || '',
-            description: elements?.scDescriptionEn?.value || '',
-          },
-          fr: {
-            src: elements?.scImageFr?.value || '',
-            title: elements?.scTitleFr?.value || '',
-            alt: elements?.scImageAltTextFr?.value || '',
-            description: elements?.scDescriptionFr?.value || '',
-          },
-        },
-      },
-    }
+    return this.extractPageDetails(elements)
   }
 
   //
@@ -197,6 +152,55 @@ class AEMService {
       description: data?.entities[0]?.properties?.description || '',
       title: data?.entities[0]?.properties?.title || '',
       error: error,
+    }
+  }
+
+  extractPageDetails(data) {
+    const { elements } = data
+    return {
+      name: {
+        en: elements?.scPageNameEn?.value || '',
+        fr: elements?.scPageNameFr?.value || '',
+      },
+      link: {
+        en: `/${elements?.scPageNameEn?.value}`,
+        fr: `/fr/${elements?.scPageNameFr?.value}`,
+      },
+      title: {
+        en: elements?.scTitleEn?.value || '',
+        fr: elements?.scTitleFr?.value || '',
+      },
+      meta: {
+        keywords: {
+          en: elements?.scKeywordsEn?.value || '',
+          fr: elements?.scKeywordsFr?.value || '',
+        },
+        owner: {
+          en: elements?.scOwnerEn?.value || '',
+          fr: elements?.scOwnerFr?.value || '',
+        },
+        description: {
+          en: elements?.scDescriptionEn?.value || '',
+          fr: elements?.scDescriptionFr?.value || '',
+        },
+        dcTerms: elements?.scSubject?.value || [],
+        audience: elements?.scAudience?.value || '',
+        type: elements?.scContentType?.value || '',
+        img: {
+          en: {
+            src: elements?.scImageEn?.value || '',
+            title: elements?.scTitleEn?.value || '',
+            alt: elements?.scImageAltTextEn?.value || '',
+            description: elements?.scDescriptionEn?.value || '',
+          },
+          fr: {
+            src: elements?.scImageFr?.value || '',
+            title: elements?.scTitleFr?.value || '',
+            alt: elements?.scImageAltTextFr?.value || '',
+            description: elements?.scDescriptionFr?.value || '',
+          },
+        },
+      },
     }
   }
 }

--- a/pages/api/AEMServiceClass.js
+++ b/pages/api/AEMServiceClass.js
@@ -100,6 +100,37 @@ class AEMService {
         en: elements?.scTitleEn?.value,
         fr: elements?.scTitleFr?.value,
       },
+      meta: {
+        keywords: {
+          en: elements?.scKeywordsEn?.value || '',
+          fr: elements?.scKeywordsFr?.value || '',
+        },
+        owner: {
+          en: elements?.scOwnerEn?.value || '',
+          fr: elements?.scOwnerFr?.value || '',
+        },
+        description: {
+          en: elements?.scDescriptionEn?.value || '',
+          fr: elements?.scDescriptionFr?.value || '',
+        },
+        dcTerms: elements?.scSubject?.value || [],
+        audience: elements?.scAudience.value || '',
+        type: elements?.scContentType.value || '',
+        img: {
+          en: {
+            src: elements?.scImageEn?.value || '',
+            title: elements?.scTitleEn?.value || '',
+            alt: elements?.scImageAltTextEn?.value || '',
+            description: elements?.scDescriptionEn?.value || '',
+          },
+          fr: {
+            src: elements?.scImageFr?.value || '',
+            title: elements?.scTitleFr?.value || '',
+            alt: elements?.scImageAltTextFr?.value || '',
+            description: elements?.scDescriptionFr?.value || '',
+          },
+        },
+      },
     }
   }
 

--- a/pages/api/AEMServiceClass.js
+++ b/pages/api/AEMServiceClass.js
@@ -86,7 +86,7 @@ class AEMService {
   async getPage(pageId) {
     const { elements } = await this.getElements(pageId)
 
-    return this.extractPageDetails(elements)
+    return this.extractPageDetails({ elements })
   }
 
   //
@@ -120,16 +120,6 @@ class AEMService {
             title: data?.entities[0]?.properties?.title || '',
             error: error,
           }
-          // let { elements, name, description, title, error } =
-          //   await this.getBenefit(
-          //     benefit.href
-          //     .replace(this.baseUrl, '')
-          //     .replace(`?dates=${this.cacheBustString}`, '')
-          //   )
-          // errorCode = error === null ? false : false
-          // return {
-          //   benefit: { elements, name, description, title } || [],
-          // }
         })
       )
     }
@@ -169,6 +159,10 @@ class AEMService {
       title: {
         en: elements?.scTitleEn?.value || '',
         fr: elements?.scTitleFr?.value || '',
+      },
+      longDescription: {
+        en: elements?.scLongDescriptionEn?.value || '',
+        fr: elements?.scLongDescriptionFr?.value || '',
       },
       meta: {
         keywords: {

--- a/pages/benefits/[id].js
+++ b/pages/benefits/[id].js
@@ -4,9 +4,7 @@ import fr from '../../locales/fr'
 import aemService from '../api/aemServiceInstance'
 import { BENEFITS } from '../../constants/aem'
 
-export default function BenefitPage({ locale, aemPage, benefit }) {
-  const benefitData = benefit.elements
-
+export default function BenefitPage({ locale, aemPage }) {
   const t = locale === 'en' ? en : fr
 
   return (
@@ -17,11 +15,11 @@ export default function BenefitPage({ locale, aemPage, benefit }) {
       bannerText={t.phaseBannerText}
     >
       <h1 className="font-extrabold text-red-800 text-3xl text-center mt-12">
-        {benefitData.scTitleEn.value}
+        {aemPage.title[locale]}
       </h1>
 
       <div className="w-9/12 mx-auto border my-24">
-        <p className="p-5">{benefitData.scLongDescriptionEn.value}</p>
+        <p className="p-5">{aemPage.longDescription[locale]}</p>
       </div>
     </Layout>
   )
@@ -40,14 +38,14 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ locale, params }) {
-  const benefit = await aemService.getBenefit(`benefits/${params.id}.json`)
-  const aemPage = aemService.extractPageDetails({ elements: benefit })
+  const aemPage = await aemService.getPage(
+    `benefits/${params.id}/${params.id}.json`
+  )
 
   return {
     props: {
       locale: locale,
       aemPage,
-      benefit,
     },
   }
 }

--- a/pages/benefits/[id].js
+++ b/pages/benefits/[id].js
@@ -2,9 +2,9 @@ import Layout from '../../components/organisms/Layout'
 import en from '../../locales/en'
 import fr from '../../locales/fr'
 import aemService from '../api/aemServiceInstance'
-import { BENEFITS, SEARCH_PAGE } from '../../constants/aem'
+import { BENEFITS } from '../../constants/aem'
 
-export default function BenefitPage({ locale, benefit }) {
+export default function BenefitPage({ locale, aemPage, benefit }) {
   const benefitData = benefit.elements
 
   const t = locale === 'en' ? en : fr
@@ -12,7 +12,7 @@ export default function BenefitPage({ locale, benefit }) {
   return (
     <Layout
       locale={locale}
-      title={benefitData.scTitleEn.value}
+      aemPage={aemPage}
       phase={t.phaseBannerTag}
       bannerText={t.phaseBannerText}
     >
@@ -41,11 +41,12 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ locale, params }) {
   const benefit = await aemService.getBenefit(`benefits/${params.id}.json`)
-  const searchPage = await aemService.getPage(SEARCH_PAGE)
+  const aemPage = aemService.extractPageDetails({ elements: benefit })
 
   return {
     props: {
       locale: locale,
+      aemPage,
       benefit,
     },
   }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,16 +1,13 @@
 import Link from 'next/link'
-import Head from 'next/head'
+import Meta from '../components/atoms/Meta'
 
-export default function Splash({ homePage }) {
+export default function Splash({ locale, page: aemPage }) {
   return (
     <section
       role="main"
       className="flex h-screen bg-cover bg-center bg-splash-page"
     >
-      <Head>
-        <title>Digital Centre</title>
-        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-      </Head>
+      <Meta locale={locale} aemPage={aemPage} />
       <div className="flex flex-col justify-center items-center m-auto">
         <div className="z-10 bg-white h-auto w-[18.75rem] xl:w-[31.25rem]">
           <h1 className="sr-only">service.canada.ca-digital-center</h1>
@@ -137,4 +134,28 @@ export default function Splash({ homePage }) {
       </div>
     </section>
   )
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      locale,
+      page: {
+        title: {
+          en: 'Digital Centre (en) + Digital Centre (fr)',
+          fr: 'Digital Centre (en) + Digital Centre (fr)',
+        },
+        meta: {
+          keywords: {
+            en: 'en + fr keywords',
+            fr: 'en + fr keywords',
+          },
+          description: {
+            en: 'en + fr description',
+            fr: 'en + fr description',
+          },
+        },
+      },
+    },
+  }
 }


### PR DESCRIPTION
- Updated `Meta` component to accept a `page` object which should come from AEM.
- Splash page is an exception so the "page" details are passed in statically as opposed to fetching from AEM. Also, there's no language switch functionality on the page itself so EN/FR content will be the same in the `page` object.
- Cleaned up `/benefits/[id]` logic for getting benefit data in `getStaticProps` -- using generic `getPage` method to get the details in a normalized way
- Updated tests