### PR TITLE
added security headers to pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,14 +14,26 @@ const contentURL = process.env.NEXT_CONTENT_API
 
 //security headers that we want on all pages
 //more info here https://nextjs.org/docs/advanced-features/security-headers
+
 const securityHeaders = [
-  {
-    key: 'Content-Security-Policy',
-    value: `frame-ancestors 'self'`, //our CSP Policy
-  },
+  // Only ever use HTTPS
   {
     key: 'Strict-Transport-Security',
-    value: 'max-age=63072000; includeSubDomains; preload',
+    value: 'max-age=31536000; includeSubDomains; preload',
+  },
+  // Prevents the browser from attempting to guess the type of content
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  // Only allow secure origin to be delivered over HTTPS
+  {
+    key: 'Referrer-Policy',
+    value: 'same-origin',
+  },
+  {
+    key: 'Content-Security-Policy',
+    value: `frame-ancestors 'self'`,
   },
 ]
 


### PR DESCRIPTION
## [DCWC-1010](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-1010) (Jira Issue)

### Description

List of proposed changes:
As per our security training, security headers should be added to each page (probably somewhere global).
Below are the security headers to be added
  // Only ever use HTTPS
  {
    key: "Strict-Transport-Security",
    value: "max-age=31536000; includeSubDomains; preload",
  },
  
  // Prevents the browser from attempting to guess the type of content
  {
    key: "X-Content-Type-Options",
    value: "nosniff",
  },
  // Only allow secure origin to be delivered over HTTPS
  {
    key: "Referrer-Policy",
    value: "same-origin",
  },
  {
    key: "Content-Security-Policy",
    value: `frame-ancestors 'self'`,
  },


**What to test for/How to test** 
Check the response headers in the network tab

### Additional Notes
NA