### PR TITLE
shortened all bilingual mappings

### DIFF
--- a/lib/pageContent.js
+++ b/lib/pageContent.js
@@ -100,7 +100,7 @@ export async function getSearchPageContent(locale) {
   const localeKey = locale === 'en' ? 'En' : 'Fr'
   const metadata = mapMetadata(localeKey, aemSearchPage)
 
-  return { metadata, benefits: mapBenefitCards(locale, AEMBenefits) }
+  return { metadata, benefits: mapBenefitCards(localeKey, AEMBenefits) }
 }
 
 export async function getIndexPageContent() {

--- a/lib/pageContent.js
+++ b/lib/pageContent.js
@@ -26,15 +26,16 @@ export async function getHomePageContent(locale) {
     aemService.getBenefits(BENEFITS),
   ])
 
+  //the suffix to choose what language to use in each bilingual object field
+  // e.g. choosing aemPage.scTitleEn or aemPage.scTitleFr
+  const localeKey = locale === 'en' ? 'En' : 'Fr'
+
   // Page metadata
-  const metadata = mapMetadata(locale, aemPage)
+  const metadata = mapMetadata(localeKey, aemPage)
 
   // Find Benefits and Services
   const findBenefitsAndServices = {
-    searchLink:
-      locale === 'en'
-        ? `/${searchPage?.scPageNameEn?.value}`
-        : `/fr/${searchPage?.scPageNameFr?.value}`,
+    searchLink: `/${searchPage['scPageName' + localeKey]?.value}`,
   }
 
   // Top Tasks
@@ -44,10 +45,7 @@ export async function getHomePageContent(locale) {
     miscellaneousRes.data.entities.forEach((item) => {
       // Extracting Top Task component content (Title and whatever else we add in AEM later on)
       if (item.properties.elements.scId.value === 'TOP-TASKS') {
-        topTasksTitle =
-          locale === 'en'
-            ? item.properties.elements.scLabelEn.value
-            : item.properties.elements.scLabelFr.value
+        topTasksTitle = item.properties.elements['scLabel' + localeKey].value
       }
       // Add any if statements to capture other misc component contents
     })
@@ -57,14 +55,8 @@ export async function getHomePageContent(locale) {
   if (topTasksReturned.data?.entities) {
     topTaskList = topTasksReturned.data.entities.map((task) => {
       return {
-        title:
-          locale === 'en'
-            ? task.properties.elements.scTitleEn.title
-            : task.properties.elements.scTitleFr.title,
-        link:
-          locale === 'en'
-            ? task.properties.elements.scLinkURLEn.value
-            : task.properties.elements.scLinkURLFr.value,
+        title: task.properties.elements['scTitle' + localeKey].title,
+        link: task.properties.elements['scLinkURL' + localeKey].value,
       }
     })
   }
@@ -77,19 +69,13 @@ export async function getHomePageContent(locale) {
   // Most Requested Pages
   const mostRequestedPages = {
     header: "todo: get 'Most Requested Page' header from AEM",
-    cards: mapBenefitCards(locale, AEMBenefits),
+    cards: mapBenefitCards(localeKey, AEMBenefits),
   }
 
   // Featured
   const featured = {
-    header:
-      locale === 'en'
-        ? 'Featured: ' + eiBenefit.elements.scTitleEn?.value
-        : '(FR) Featured: ' + eiBenefit.elements.scTitleFr?.value,
-    body:
-      locale === 'en'
-        ? eiBenefit.elements.scDescriptionEn?.value
-        : eiBenefit.elements.scDescriptionFr?.value,
+    header: eiBenefit.elements['scTitle' + localeKey]?.value,
+    body: eiBenefit.elements['scDescription' + localeKey]?.value,
     imgSrc:
       'https://www.canada.ca/content/dam/decd-endc/images/autumn_leaves_woman_hands.png',
     imgAlt: '',
@@ -111,7 +97,8 @@ export async function getSearchPageContent(locale) {
     aemService.getBenefits(BENEFITS),
   ])
 
-  const metadata = mapMetadata(locale, aemSearchPage)
+  const localeKey = locale === 'en' ? 'En' : 'Fr'
+  const metadata = mapMetadata(localeKey, aemSearchPage)
 
   return { metadata, benefits: mapBenefitCards(locale, AEMBenefits) }
 }
@@ -136,91 +123,43 @@ export async function getBenefitsPageContent(locale, benefitId) {
   return { metadata, benefit }
 }
 
-function mapMetadata(locale, aemPage) {
-  const toLocale = locale === 'en' ? 'fr' : 'en'
+function mapMetadata(localeKey, aemPage) {
   return {
-    name:
-      locale === 'en'
-        ? aemPage.scPageNameEn?.value
-        : aemPage.scPageNameFr?.value,
-    title:
-      locale === 'en' ? aemPage.scTitleEn?.value : aemPage.scTitleFr?.value,
+    name: aemPage['scPageName' + localeKey]?.value,
+    title: aemPage['scTitle' + localeKey]?.value,
     toggleLangLink:
-      toLocale === 'fr'
+      localeKey === 'En'
         ? `/fr/${aemPage.scPageNameFr?.value}`
         : `/${aemPage.scPageNameEn?.value}`,
-    currentLink:
-      locale === 'en'
-        ? aemPage.scPageNameEn?.value
-        : aemPage.scPageNameFr?.value,
-    keywords:
-      locale === 'en'
-        ? aemPage.scKeywordsEn?.value || ''
-        : aemPage.scKeywordsFr?.value || '',
-    owner:
-      locale === 'en'
-        ? aemPage.scOwnerEn?.value || ''
-        : aemPage.scOwnerFr?.value || '',
-    description:
-      locale === 'en'
-        ? aemPage.scDescriptionEn?.value || ''
-        : aemPage.scDescriptionFr?.value || '',
+    currentLink: aemPage['scPageName' + localeKey]?.value,
+    keywords: aemPage['scKeywords' + localeKey]?.value || '',
+    owner: aemPage['scOwner' + localeKey]?.value || '',
+    description: aemPage['scDescription' + localeKey]?.value || '',
     dcTerms: aemPage.scSubject?.value,
     audience: aemPage.scAudience?.value || null,
     type: aemPage.scContentType?.value,
     img: {
-      src:
-        locale === 'en'
-          ? aemPage.scImageEn?.value || ''
-          : aemPage.scImageFr?.value || '',
-      title:
-        locale === 'en' ? aemPage.scTitleEn?.value : aemPage.scTitleFr?.value,
-      alt:
-        locale === 'en'
-          ? aemPage.scImageAltTextEn?.value || ''
-          : aemPage.scImageAltTextFr?.value || '',
-      description:
-        locale === 'en'
-          ? aemPage.scDescriptionEn?.value || ''
-          : aemPage.scDescriptionFr?.value || '',
+      src: aemPage['scImage' + localeKey]?.value || '',
+      title: aemPage['scTitle' + localeKey]?.value,
+      alt: aemPage['scImageAltText' + localeKey]?.value || '',
+      description: aemPage['scDescription' + localeKey]?.value || '',
     },
   }
 }
 
 // Maps AEM benfits object to react cards
-function mapBenefitCards(locale, AEMBenefits) {
+function mapBenefitCards(localeKey, AEMBenefits) {
   if (AEMBenefits.benefits) {
     return AEMBenefits.benefits.map((benefit) => {
+      const elems = benefit.elements
       return {
         key: benefit.elements.scPageNameEn.value,
-        title:
-          locale === 'en'
-            ? benefit.elements.scTitleEn.value
-            : benefit.elements.scTitleFr.value,
-        tag: (
-          locale === 'en'
-            ? benefit.elements.scProgramEn?.value
-            : benefit.elements.scProgramFr?.value
-        )
-          ? locale === 'en'
-            ? benefit.elements.scProgramEn?.value
-            : benefit.elements.scProgramFr?.value
-          : null,
-        text: (
-          locale === 'en'
-            ? benefit.elements.scDescriptionEn?.value
-            : benefit.elements.scDescriptionFr?.value
-        )
-          ? locale === 'en'
-            ? benefit.elements.scDescriptionEn?.value
-            : benefit.elements.scDescriptionFr?.value
-          : null,
-        callToActionText:
-          locale === 'en'
-            ? benefit.elements.scCallToActionEn?.value
-            : benefit.elements.scCallToActionFr.value,
+        title: elems['scTitle' + localeKey].value,
+        tag: elems['scProgram' + localeKey]?.value || null,
+        text: elems['scDescription' + localeKey]?.value || null,
+        callToActionText: elems['scCallToAction' + localeKey].value,
         callToActionHref: `/benefits/${benefit.name}`.toLowerCase(),
-        btnId: 'btn-' + benefit.elements.scPageNameEn.value,
+        btnId: 'btn-' + elems.scPageNameEn.value,
       }
     })
   }


### PR DESCRIPTION
## [DCWC-1104](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-1104)

### Description
Shortened bilingual mappings by using `object[keyName + locale].value` instead of the old 3-line ternary expressions.

List of proposed changes:
- Shortened bilingual mappings   

### What to test for/How to test

### Additional Notes
