### PR TITLE
Dcwc 114 error pages

### DIFF
--- a/__tests__/pages/404.test.js
+++ b/__tests__/pages/404.test.js
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import Error404 from '../../pages/404'
+
+describe('404', () => {
+  it('renders without crashing', () => {
+    render(<Error404 />)
+    expect(screen.getByText('404 - Page Not Found')).toBeInTheDocument()
+  })
+})

--- a/__tests__/pages/404.test.js
+++ b/__tests__/pages/404.test.js
@@ -8,6 +8,6 @@ import Error404 from '../../pages/404'
 describe('404', () => {
   it('renders without crashing', () => {
     render(<Error404 />)
-    expect(screen.getByText('404 - Page Not Found')).toBeInTheDocument()
+    expect(screen.getByText('404 Error - Page Not Found')).toBeInTheDocument()
   })
 })

--- a/__tests__/pages/500.test.js
+++ b/__tests__/pages/500.test.js
@@ -1,0 +1,15 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import Error500 from '../../pages/500'
+
+describe('500', () => {
+  it('renders without crashing', () => {
+    render(<Error500 />)
+    expect(
+      screen.getByText('500 - Server-side error occurred')
+    ).toBeInTheDocument()
+  })
+})

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,3 @@
+export default function Error404() {
+  return <h1>404 - Page Not Found</h1>
+}

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,3 +1,3 @@
 export default function Error404() {
-  return <h1>404 - Page Not Found</h1>
+  return <h1>404 Error - Page Not Found</h1>
 }

--- a/pages/500.js
+++ b/pages/500.js
@@ -1,0 +1,3 @@
+export default function Error500() {
+  return <h1>500 - Server-side error occurred</h1>
+}


### PR DESCRIPTION
## [DCWC-1144](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-1144)

- Very short PR to add the 500.js and 404.js page. Both are empty.
- Added rendering tests in our unit tests.

### Notes
 - I couldn't figure out how to render the 500.js in dev mode. i think its built on purpose this way to help developers see the error message when running the app locally.