### PR TITLE
Increase drop shadow and grey in cards

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,7 @@ module.exports = {
     extend: {
       colors: {
         'gray': {
-          lighter: '#F6F6F6',
+          lighter: '#F7F7F7',
           light: '#DBDBDB',
           solid: '#B9B9B9',
           dark: '#7F8C8D',
@@ -86,7 +86,7 @@ module.exports = {
       }),
       boxShadow: {
         card: '0px 2px 8px rgba(0, 0, 0, 0.25)',
-        tile: '0px 0px 25px 5px rgba(0,0,0,0.1)',
+        tile: '0px 0px 25px 5px rgba(0,0,0,0.25)',
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,7 @@ module.exports = {
     extend: {
       colors: {
         'gray': {
-          lighter: '#F7F7F7',
+          lighter: '#F3F3F3',
           light: '#DBDBDB',
           solid: '#B9B9B9',
           dark: '#7F8C8D',


### PR DESCRIPTION
## [DCWC-1535](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-1535) (Increase drop shadow and grey in cards)

### Description

List of proposed changes:

- Increase drop shadow opacity from 10% to 25% 
- Darker grey bar behind icons. 


### What to test for/How to test

### Additional Notes
