### PR TITLE
added info message component

### DIFF
--- a/components/atoms/InfoMessage.js
+++ b/components/atoms/InfoMessage.js
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types'
+import { Message } from '@dts-stn/decd-design-system'
+
+export default function InfoMessage(props) {
+  return (
+    // the message types can be one of warning, info, success or danger"
+    // alertIconAltText/Id translation can be done with _info etc (alertIconId_info)
+    <Message
+      type={props.type}
+      id={props.id}
+      alert_icon_alt_text={props.alertIconAltText}
+      alert_icon_id={props.alertIconId}
+      message_heading={props.messageHeading}
+      message_body={props.messageBody}
+    />
+  )
+}
+
+InfoMessage.propTypes = {
+  // type of message to be displayed
+  type: PropTypes.string.isRequired,
+
+  // icon alt text
+  alertIconAltText: PropTypes.string.isRequired,
+
+  // icon id
+  alertIconId: PropTypes.string.isRequired,
+
+  // id of the element
+  id: PropTypes.string.isRequired,
+
+  // text to be displayed for the message heading
+  messageHeading: PropTypes.string.isRequired,
+
+  // text to be displayed for the message body
+  messageBody: PropTypes.string.isRequired,
+}

--- a/components/atoms/InfoMessage.test.js
+++ b/components/atoms/InfoMessage.test.js
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { axe, toHaveNoViolations } from 'jest-axe'
+
+import InfoMessage from './InfoMessage'
+
+expect.extend(toHaveNoViolations)
+
+describe('Design System Info Message tests', () => {
+  const { container } = render(<InfoMessage />)
+  it('renders InfoMessage', () => {
+    expect(container).toBeTruthy()
+  })
+
+  it('has no a11y violations', async () => {
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/components/atoms/InfoMessage.test.js
+++ b/components/atoms/InfoMessage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { axe, toHaveNoViolations } from 'jest-axe'
 

--- a/components/molecules/Greeting.js
+++ b/components/molecules/Greeting.js
@@ -1,3 +1,4 @@
+import InfoMessage from '../atoms/InfoMessage'
 import en from '../../locales/en'
 import fr from '../../locales/fr'
 
@@ -8,8 +9,17 @@ export default function Greeting(props) {
     <div>
       <div className="grid grid-cols-1 divide-y divide-red-600 font-display">
         <div className="py-4 text-4xl font-bold">{`${t.greeting} ${props.name}`}</div>
-        <div className="pt-4 text-xl">{t.welcome}</div>
+        <div className="py-4 text-xl">{t.welcome}</div>
       </div>
+      <InfoMessage
+        type="success"
+        id="success"
+        alertIconAltText={t.alertIconAltText_success}
+        alertIconId={t.alertIconId_success}
+        messageHeading={t.messageHeading}
+        messageBody={t.messageBody}
+      />
+
       <div className="text-3xl font-bold mt-10">{t.myBenefitsAndServices}</div>
     </div>
   )

--- a/locales/en.js
+++ b/locales/en.js
@@ -214,6 +214,19 @@ export default {
   serviceCanada: 'Service Canada',
   myBenefitsAndServices: 'My Benefits and Services',
 
+  // Info Message
+  alertIconAltText_success: 'success icon',
+  alertIconId_success: 'success icon',
+  alertIconAltText_warning: 'warning icon',
+  alertIconId_warning: 'warning icon',
+  alertIconAltText_info: 'info icon',
+  alertIconId_info: 'info icon',
+  alertIconAltText_danger: 'danger icon',
+  alertIconId_danger: 'danger icon',
+  messageHeading: 'COVID-19 New services and service changes',
+  messageBody:
+    'Find out about new support for Canadians during the COVID-19 pandemic and how Service Canada’s services are affectedFind out about new support for Canadians during the COVID-19 pandemic and how Service Canada’s services are affected',
+
   // Benefit Names
   cpp: 'Canada Pension Plan',
   oas: 'Old Age Security',

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -216,6 +216,19 @@ export default {
   serviceCanada: '(FR)Service Canada',
   myBenefitsAndServices: '(FR)My Benefits and Services',
 
+  // Info Message
+  alertIconAltText_success: '(FR)success icon',
+  alertIconId_success: '(FR)success icon',
+  alertIconAltText_warning: '(FR)warning icon',
+  alertIconId_warning: '(FR)warning icon',
+  alertIconAltText_info: '(FR)info icon',
+  alertIconId_info: '(FR)info icon',
+  alertIconAltText_danger: '(FR)danger icon',
+  alertIconId_danger: '(FR)danger icon',
+  messageHeading: '(FR)COVID-19 New services and service changes',
+  messageBody:
+    '(FR)Find out about new support for Canadians during the COVID-19 pandemic and how Service Canada’s services are affectedFind out about new support for Canadians during the COVID-19 pandemic and how Service Canada’s services are affected',
+
   // Benefit Names
   cpp: '(FR)Canada Pension Plan',
   oas: '(FR)Old Age Security',


### PR DESCRIPTION
## [DCWC-1628](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-1628) (Jira Issue)

### Description
Added the message component from the design system as InfoMessage component
Added it to the Greetings component so that it appears between the welcome text and My Benefits text. 

List of proposed changes:
There are 4 types of messages that can be created, warning, info, success or danger. 

### What to test for/How to test

### Additional Notes
