### PR TITLE
DCWC-1780-1781 Profile Auth - Breadcrumbs on Account Page

### DIFF
--- a/components/molecules/DSHeader.js
+++ b/components/molecules/DSHeader.js
@@ -5,12 +5,26 @@ import { signOut } from 'next-auth/react'
 
 export default function DSHeader(props) {
   const t = props.locale === 'en' ? en : fr
+  const defaultBreadcrumbs = [
+    {
+      link: t.url_canada_ca,
+      text: t.canada_ca,
+    },
+    {
+      link: t.url_serviceCanada,
+      text: t.serviceCanada,
+    },
+  ]
   return (
     <Header
       id="header"
       lang={props.locale}
       linkPath={props.langToggleLink}
-      breadCrumbItems={props.breadCrumbItems}
+      breadCrumbItems={
+        props.breadCrumbItems
+          ? defaultBreadcrumbs.concat(props.breadCrumbItems)
+          : defaultBreadcrumbs
+      }
       isAuthenticated={props.isAuth}
       menuProps={{
         craPath: t.craPath,

--- a/components/molecules/DSHeader.js
+++ b/components/molecules/DSHeader.js
@@ -10,20 +10,7 @@ export default function DSHeader(props) {
       id="header"
       lang={props.locale}
       linkPath={props.langToggleLink}
-      breadCrumbItems={[
-        {
-          link: t.url_canada_ca,
-          text: t.canada_ca,
-        },
-        {
-          link: t.url_serviceCanada,
-          text: t.serviceCanada,
-        },
-        {
-          link: t.url_myBenefitsAndServices,
-          text: t.myBenefitsAndServices,
-        },
-      ]}
+      breadCrumbItems={props.breadCrumbItems}
       isAuthenticated={props.isAuth}
       menuProps={{
         craPath: t.craPath,

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -71,6 +71,7 @@ export default function Layout(props) {
             locale={props.locale}
             langToggleLink={props.langToggleLink}
             isAuth={props.isAuth}
+            breadCrumbItems={props.breadCrumbItems}
           />
         </>
       ) : (
@@ -187,6 +188,8 @@ Layout.propTypes = {
    * Toggle use of footer
    */
   displayFooter: PropTypes.bool,
+
+  breadCrumbItems: PropTypes.array,
 }
 
 Layout.defaultProps = {

--- a/locales/en.js
+++ b/locales/en.js
@@ -373,6 +373,7 @@ export default {
   url_serviceCanada:
     'https://www.canada.ca/en/employment-social-development/corporate/portfolio/service-canada.html',
   url_myBenefitsAndServices: '/dashboard',
+  url_profileAndSecuritySettings: '/profile',
 
   // Benefit card header URLs
   url_statusAndMessages: '/dashboard',

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -365,6 +365,7 @@ export default {
   url_serviceCanada:
     'https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html',
   url_myBenefitsAndServices: '/fr/dashboard',
+  url_profileAndSecuritySettings: '/fr/profile',
 
   // Benefit card header URLs
   url_statusAndMessages: '/fr/dashboard',

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -3,6 +3,8 @@ import NoBenefitCard from '../components/molecules/NoBenefitCard'
 import BenefitApplicationCard from '../components/molecules/BenefitApplicationCard'
 import { LayoutContainer } from '@dts-stn/decd-design-system'
 import Greeting from '../components/molecules/Greeting'
+import en from '../locales/en'
+import fr from '../locales/fr'
 import {
   SUBMITTED_CPP,
   ACTIVE_CPP,
@@ -77,6 +79,7 @@ export default function Dashboard(props) {
         metadata={props.metadata}
         langToggleLink={props.langToggleLink}
         isAuth={props.isAuth}
+        breadCrumbItems={props.breadCrumbItems}
       >
         <LayoutContainer>
           <div className="mb-8">
@@ -202,7 +205,6 @@ export async function getServerSideProps({ req, locale }) {
   // const session = await getSession({ req })
   // const isAuth = session ? true : false
 
-
   const metadata = {
     title: 'Digital Centre (en) + Digital Centre (fr)',
     keywords: 'en + fr keywords',
@@ -210,12 +212,27 @@ export async function getServerSideProps({ req, locale }) {
   }
 
   const langToggleLink = locale === 'en' ? '/fr/dashboard' : '/dashboard'
-
+  const t = locale === 'en' ? en : fr
   const usersBenefts = [] // to be retrieved by API
   const cppData = await GetCPPProgramData()
   if (cppData) usersBenefts.push(cppData)
   const eiData = await GetEIProgramData()
   if (eiData) usersBenefts.push(eiData)
+
+  const breadCrumbItems = [
+    {
+      link: t.url_canada_ca,
+      text: t.canada_ca,
+    },
+    {
+      link: t.url_serviceCanada,
+      text: t.serviceCanada,
+    },
+    {
+      link: t.url_myBenefitsAndServices,
+      text: t.myBenefitsAndServices,
+    },
+  ]
 
   return {
     props: {
@@ -225,6 +242,7 @@ export async function getServerSideProps({ req, locale }) {
       locale,
       langToggleLink,
       metadata,
+      breadCrumbItems,
     },
   }
 }

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -3,8 +3,6 @@ import NoBenefitCard from '../components/molecules/NoBenefitCard'
 import BenefitApplicationCard from '../components/molecules/BenefitApplicationCard'
 import { LayoutContainer } from '@dts-stn/decd-design-system'
 import Greeting from '../components/molecules/Greeting'
-import en from '../locales/en'
-import fr from '../locales/fr'
 import {
   SUBMITTED_CPP,
   ACTIVE_CPP,

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -212,7 +212,6 @@ export async function getServerSideProps({ req, locale }) {
   }
 
   const langToggleLink = locale === 'en' ? '/fr/dashboard' : '/dashboard'
-  const t = locale === 'en' ? en : fr
   const usersBenefts = [] // to be retrieved by API
   const cppData = await GetCPPProgramData()
   if (cppData) usersBenefts.push(cppData)

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -219,21 +219,6 @@ export async function getServerSideProps({ req, locale }) {
   const eiData = await GetEIProgramData()
   if (eiData) usersBenefts.push(eiData)
 
-  const breadCrumbItems = [
-    {
-      link: t.url_canada_ca,
-      text: t.canada_ca,
-    },
-    {
-      link: t.url_serviceCanada,
-      text: t.serviceCanada,
-    },
-    {
-      link: t.url_myBenefitsAndServices,
-      text: t.myBenefitsAndServices,
-    },
-  ]
-
   return {
     props: {
       advertisingCards: BuildAdvertisingCards(usersBenefts),
@@ -242,7 +227,6 @@ export async function getServerSideProps({ req, locale }) {
       locale,
       langToggleLink,
       metadata,
-      breadCrumbItems,
     },
   }
 }

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -167,20 +167,8 @@ export async function getStaticProps({ locale }) {
 
   const breadCrumbItems = [
     {
-      link: t.url_canada_ca,
-      text: t.canada_ca,
-    },
-    {
-      link: t.url_serviceCanada,
-      text: t.serviceCanada,
-    },
-    {
       link: t.url_myBenefitsAndServices,
       text: t.myBenefitsAndServices,
-    },
-    {
-      link: t.url_profileAndSecuritySettings,
-      text: t.profileAndSecuritySettings,
     },
   ]
 

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -95,6 +95,8 @@ export default function Profile(props) {
         displayDSFooter={true}
         metadata={props.metadata}
         langToggleLink={props.langToggleLink}
+        isAuth={props.isAuth}
+        breadCrumbItems={props.breadCrumbItems}
       >
         <LayoutContainer>
           <div className="col-span-12">
@@ -155,12 +157,40 @@ export default function Profile(props) {
 
 export async function getStaticProps({ locale }) {
   const langToggleLink = locale === 'en' ? '/fr/profile' : '/profile'
+  const t = locale === 'en' ? en : fr
+
   const metadata = {
     title: 'Digital Centre (en) + Digital Centre (fr)',
     keywords: 'en + fr keywords',
     description: 'en + fr description',
   }
+
+  const breadCrumbItems = [
+    {
+      link: t.url_canada_ca,
+      text: t.canada_ca,
+    },
+    {
+      link: t.url_serviceCanada,
+      text: t.serviceCanada,
+    },
+    {
+      link: t.url_myBenefitsAndServices,
+      text: t.myBenefitsAndServices,
+    },
+    {
+      link: t.url_profileAndSecuritySettings,
+      text: t.profileAndSecuritySettings,
+    },
+  ]
+
   return {
-    props: { locale, langToggleLink, metadata },
+    props: {
+      locale,
+      langToggleLink,
+      metadata,
+      isAuth: true,
+      breadCrumbItems,
+    },
   }
 }


### PR DESCRIPTION
## [DCWC-1780](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-1780) (Jira Issue)
## [DCWC-1781](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-1781) (Jira Issue)

### Description
- Combined two smaller tickets
List of proposed changes:

- Adds isAuth:true to profile page to display header menu
- Moves breadCrumbItems into page props in order to display custom breadcrumbs on each page
- Adds profile and security settings breadcrumb

### What to test for/How to test

### Additional Notes
