### PR TITLE
fix for the overflowing text

### DIFF
--- a/components/molecules/BenefitApplicationCard.js
+++ b/components/molecules/BenefitApplicationCard.js
@@ -32,9 +32,9 @@ const BenefitApplicationCard = (props) => {
           id={`${benefitType}-${benefitSubType}-app-card`}
           className="col-span-1 py-4 md:px-0 lg:px-3"
         >
-          <div className="font-bold font-display text-4xl sm:text-2xl lg:text-4xl mb-2 w-44 sm:w-32 lg:w-44">
+          <h2 className="font-bold font-display text-4xl sm:text-2xl lg:text-4xl mb-2 w-44 sm:w-32 lg:w-44">
             {benefitName}
-          </div>
+          </h2>
           <div className="font-bold font-display text-md sm:text-md lg:text-md mb-2 w-44 sm:w-32 lg:w-44">
             {t[benefitSubType]}
           </div>
@@ -45,10 +45,10 @@ const BenefitApplicationCard = (props) => {
             <p className="text-3xl sm:text-2xl lg:text-3xl mb-5">
               {t.youMightBeEligible}
             </p>
-            <a className="text-xl">{t.learnMoreAbout}</a>
+            <p className="text-xl whitespace-nowrap">{t.learnMoreAbout}</p>
             <a
               href={props.benefitApplication.learnMoreLink}
-              className="text-xl underline hover:text-bright-blue-solid whitespace-pre"
+              className="text-xl underline hover:text-bright-blue-solid whitespace-pre-wrap"
             >
               {getBenefitNameString()}
             </a>


### PR DESCRIPTION
## [DCWC-1790](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-1790) (Jira Issue)

### Description
The text in the "You might be eligible" card didn't wrap and was extending over the icons and causing mobile to have a horizontal scroll bar. 
List of proposed changes:
The link text now wraps and stays in the designated area. 
the LInk text is on the line below the other text.
made the paragraph text a p tag from an a tag as it didn't appear to be a link.
added an h2 for the card

### What to test for/How to test

### Additional Notes
