### PR TITLE
adding a dummy access token for auth to API stubs

### DIFF
--- a/pages/api/programData/cpp.js
+++ b/pages/api/programData/cpp.js
@@ -3,6 +3,7 @@ import { mockData } from '../../../mockdata/MockData'
 import { getCookie } from 'cookies-next'
 
 export default async function handler(req, res) {
+  const accessToken = 'dummyAccessToken'
   if (req.method === 'GET') {
     try {
       let userData
@@ -14,6 +15,7 @@ export default async function handler(req, res) {
         const reposnseData = await fetch(process.env.CPP_ACTIVE_BENEFIT_URL, {
           headers: new Headers({
             'Ocp-Apim-Subscription-Key': process.env.OCP_APIM_SUBSCRIPTION_KEY,
+            'Access-Token': accessToken,
           }),
         })
         userData = [await reposnseData.json()]

--- a/pages/api/programData/ei.js
+++ b/pages/api/programData/ei.js
@@ -3,6 +3,7 @@ import { mockData } from '../../../mockdata/MockData'
 import { getCookie } from 'cookies-next'
 
 export default async function handler(req, res) {
+  const accessToken = 'dummyAccessToken'
   if (req.method === 'GET') {
     try {
       let userData
@@ -14,6 +15,7 @@ export default async function handler(req, res) {
         const responseData = await fetch(process.env.EI_ACTIVE_BENEFIT_URL, {
           headers: new Headers({
             'Ocp-Apim-Subscription-Key': process.env.OCP_APIM_SUBSCRIPTION_KEY,
+            'Access-Token': accessToken,
           }),
         })
         userData = [await responseData.json()]


### PR DESCRIPTION
[DCWC-1885](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-1885)

### Description

List of proposed changes:

- Add a dummy access token to the interop api requests

### Additional Notes

This will be replaced with the token from RAOIDC once that authentication is in place.