### PR TITLE
Cards will now have localized date and currency strings

### DIFF
--- a/components/molecules/BenefitCardHeaderSummary.js
+++ b/components/molecules/BenefitCardHeaderSummary.js
@@ -2,7 +2,7 @@ import propTypes from 'prop-types'
 import en from '../../locales/en'
 import fr from '../../locales/fr'
 import { SummaryTypes } from '../../constants/SummaryTypes'
-import { formatDate } from '../../lib/Utils'
+import { formatDate, formatMoney } from '../../lib/Utils'
 
 export default function BenefitCardHeaderSummary(props) {
   const t = props.locale === 'en' ? en : fr
@@ -22,7 +22,7 @@ export default function BenefitCardHeaderSummary(props) {
       case SummaryTypes.LastNetPayment:
         return (
           <p className="text-3xl">
-            {t.netAmount.replace('{0}', props.summary.value)}
+            {formatMoney(props.summary.value, props.locale)}
           </p>
         )
         break
@@ -32,7 +32,11 @@ export default function BenefitCardHeaderSummary(props) {
       case SummaryTypes.EstimatedDecisionDate:
       case SummaryTypes.LastPaymentDate:
       case SummaryTypes.LatestStatusMessage:
-        return <p className="text-lg">{formatDate(props.summary.value)}</p>
+        return (
+          <p className="text-lg">
+            {formatDate(props.summary.value, props.locale)}
+          </p>
+        )
         break
       case SummaryTypes.RequestedBenefit:
       case SummaryTypes.BenefitAffected:

--- a/components/molecules/BenefitCardHeaderSummary.test.js
+++ b/components/molecules/BenefitCardHeaderSummary.test.js
@@ -9,7 +9,7 @@ import { FormatSummary } from '../../lib/BenefitsMapping'
 expect.extend(toHaveNoViolations)
 
 describe('BenefitCardHeaderSummary', () => {
-  const netPay = 30
+  const netPay = 30.21
   const summary = FormatSummary(SummaryTypes.LastNetPayment, netPay)
 
   const { container } = render(

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -1,4 +1,12 @@
-export function formatDate(string) {
+export function formatDate(string, locale) {
   const options = { year: 'numeric', month: 'long', day: 'numeric' }
-  return new Date(string).toLocaleDateString([], options)
+  return new Date(string).toLocaleDateString(locale + '-CA', options)
+}
+
+export function formatMoney(money, locale) {
+  let CAD = Intl.NumberFormat(locale + '-CA', {
+    style: 'currency',
+    currency: 'CAD',
+  })
+  return CAD.format(money)
 }

--- a/locales/en.js
+++ b/locales/en.js
@@ -323,7 +323,6 @@ export default {
   viewPaymentHistory: 'View my payments',
   transactionDate: 'Transaction date:',
   agreementStatus: 'Agreement status:',
-  netAmount: '${0}',
   benefitDurationReached: 'Your current benefit duration has been reached.',
 
   // Benefit Card details

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -311,7 +311,6 @@ export default {
   viewPaymentHistory: '(FR)View my payments',
   transactionDate: '(FR)Transaction date:',
   agreementStatus: '(FR)Agreement status:',
-  netAmount: '{0}$',
   benefitDurationReached:
     "Votre durée d'indemnisation actuelle a été atteinte.",
 


### PR DESCRIPTION
## [DCWC-1890](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-1890) [DCWC-1891](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-1891)

### Description
Adds localisation for dates and currencies on the cards. Also added a `formatMoney()` method for future convenience

List of proposed changes:

- Localisation of dates and currencies
- Removed currency strings from locale files as they're no longer needed

### What to test for/How to test

### Additional Notes
