### PR TITLE
Benefit card component reusability

### DIFF
--- a/components/atoms/StatusBadge.js
+++ b/components/atoms/StatusBadge.js
@@ -11,8 +11,7 @@ export default function StatusBadge(props) {
       <h2
         className={`font-medium font-display text-black text-lg px-5 py-1 sm:mb-5 w-full sm:w-1/3 sm:mr-14 rounded-t-lg sm:rounded-t-none sm:rounded-b-lg  ${props.className} `}
       >
-        <span className="sr-only">{props.program} </span>
-        {props.status ?? 'No status found'}
+        {props.status}
       </h2>
     </div>
   )
@@ -20,16 +19,11 @@ export default function StatusBadge(props) {
 
 StatusBadge.propTypes = {
   /**
-   * className
+   * className to apply class such as color to badge
    */
   className: propTypes.string,
   /**
-   *
+   * The status text to be displayed
    */
   status: propTypes.string,
-  program: propTypes.string,
-  /**
-   *
-   */
-  locale: propTypes.string,
 }

--- a/components/atoms/StatusBadge.js
+++ b/components/atoms/StatusBadge.js
@@ -1,35 +1,18 @@
 import propTypes from 'prop-types'
 import { StatusCodes } from '../../constants/StatusCodes'
-import en from '../../locales/en'
-import fr from '../../locales/fr'
 
 /**
  * Displays the Status Badge at the top of the card
  */
 
 export default function StatusBadge(props) {
-  const t = props.locale === 'en' ? en : fr
   return (
     <div className="flex justify-end rounded-t-lg ">
       <h2
-        className={`font-medium font-display text-black text-lg px-5 py-1 sm:mb-5 w-full sm:w-1/3 sm:mr-14 rounded-t-lg sm:rounded-t-none sm:rounded-b-lg ${
-          props.className
-        }
-        ${
-          props.status === StatusCodes.inPayment
-            ? 'bg-status-inPayment'
-            : props.status === StatusCodes.benefitUpdate
-            ? 'bg-status-benefitUpdate'
-            : props.status === StatusCodes.applicationReceived ||
-              props.status === StatusCodes.decisionSent
-            ? 'bg-status-applicationReceived'
-            : props.status == StatusCodes.paymentHold
-            ? 'bg-status-hold'
-            : 'bg-status-inactive'
-        }`}
+        className={`font-medium font-display text-black text-lg px-5 py-1 sm:mb-5 w-full sm:w-1/3 sm:mr-14 rounded-t-lg sm:rounded-t-none sm:rounded-b-lg  ${props.className} `}
       >
-        <span className="sr-only">{t[props.programCode]} </span>
-        {t[props.status] ?? 'No status found'}
+        <span className="sr-only">{props.program} </span>
+        {props.status ?? 'No status found'}
       </h2>
     </div>
   )
@@ -44,7 +27,7 @@ StatusBadge.propTypes = {
    *
    */
   status: propTypes.string,
-  programCode: propTypes.string,
+  program: propTypes.string,
   /**
    *
    */

--- a/components/molecules/BenefitCardHeaderSummary.js
+++ b/components/molecules/BenefitCardHeaderSummary.js
@@ -1,92 +1,41 @@
 import propTypes from 'prop-types'
-import en from '../../locales/en'
-import fr from '../../locales/fr'
-import { SummaryTypes } from '../../constants/SummaryTypes'
-import { formatDate, formatMoney } from '../../lib/Utils'
 
 export default function BenefitCardHeaderSummary(props) {
-  const t = props.locale === 'en' ? en : fr
-  const typesWithLinks = [
-    SummaryTypes.PaymentAmount,
-    SummaryTypes.LatestStatus,
-    SummaryTypes.PresentStatus,
-    SummaryTypes.LastPaymentDate,
-    SummaryTypes.LastNetPayment,
-    SummaryTypes.LatestStatusMessage,
-  ]
-
-  const getBenefitCardValue = () => {
-    switch (props.summary.type) {
-      case SummaryTypes.PaymentAmount:
-      case SummaryTypes.LastPayment:
-      case SummaryTypes.LastNetPayment:
-        return (
-          <p className="text-3xl">
-            {formatMoney(props.summary.value, props.locale)}
-          </p>
-        )
-        break
-      case SummaryTypes.NextPayment:
-      case SummaryTypes.NextReport:
-      case SummaryTypes.LatestStatus:
-      case SummaryTypes.EstimatedDecisionDate:
-      case SummaryTypes.LastPaymentDate:
-      case SummaryTypes.LatestStatusMessage:
-        return (
-          <p className="text-lg">
-            {formatDate(props.summary.value, props.locale)}
-          </p>
-        )
-        break
-      case SummaryTypes.RequestedBenefit:
-      case SummaryTypes.BenefitAffected:
-      case SummaryTypes.ActiveBenefit:
-        return <p className="text-lg">{t[props.summary.value]}</p>
-        break
-      case SummaryTypes.PresentStatus:
-      case SummaryTypes.NextPaymentDate:
-        return <p className="text-lg">{props.summary.value}</p>
-      default:
-        return null
-        break
-    }
-  }
-
-  const getBenefitCardStatus = () => {
-    switch (props.summary.type) {
-      case SummaryTypes.LatestStatus:
-        return (
-          <p className="text-lg">
-            {t.eiMessages[props.summary.status] ?? null}
-          </p>
-        )
-      default:
-        return <p className="font-bold">{props.summary.status ?? null}</p>
-    }
-  }
-
   return (
     <li className="w-full">
-      <p className="font-bold">{t[props.summary.type].title}</p>
-      {getBenefitCardStatus()}
-      {getBenefitCardValue()}
+      {/* Title */}
+      <p className="font-bold">{props.summary.title}</p>
 
-      {!typesWithLinks.find((t) => t === props.summary.type) ? null : (
+      {/* Optional Status */}
+      {props.summary.status ? (
+        <p className={props.summary.statusClassName}>{props.summary.status}</p>
+      ) : null}
+
+      {/* Summary */}
+      <p className={props.summary.valueClassName}>{props.summary.value}</p>
+
+      {/* Optional Link */}
+      {props.summary.link ? (
         <a
-          href={t[props.summary.type].link}
+          href={props.summary.link}
           className="mt-1 text-link-blue-default underline text-base hover:text-link-blue-hover"
         >
-          {t[props.summary.type].linkText}
+          {props.summary.linkText}
         </a>
-      )}
+      ) : null}
     </li>
   )
 }
 
 BenefitCardHeaderSummary.propTypes = {
-  locale: propTypes.string.isRequired,
   summary: propTypes.shape({
     type: propTypes.string.isRequired,
+    title: propTypes.string.isRequired,
+    status: propTypes.string,
+    statusClassName: propTypes.string,
     value: propTypes.any.isRequired,
+    valueClassName: propTypes.string,
+    link: propTypes.string,
+    linkText: propTypes.string,
   }),
 }

--- a/components/molecules/BenefitTasks.js
+++ b/components/molecules/BenefitTasks.js
@@ -1,24 +1,19 @@
 import PropTypes from 'prop-types'
-import HorizontalRule from '../atoms/HorizontalRule'
-import en from '../../locales/en'
-import fr from '../../locales/fr'
 
 export default function BenefitTasks(props) {
-  const t = props.locale === 'en' ? en : fr
-
   return (
     <div className="bg-gray-lighter px-4 py-3 sm:px-8 sm:py-6 h-full border-b">
       <h5 className="font-display font-bold text-xl">
-        {t[props.taskList.header]}
+        {props.taskList.header}
       </h5>
       <ul className="grid sm:grid-cols-4 gap-x-7 justify-items-start w-full pt-6">
         {props.taskList.tasks.map((value, index) => {
           return (
             <li key={index} className="font-display font-bold text-left pb-7">
-              <a href={t[value.taskLink]} className="flex">
+              <a href={value.taskLink} className="flex">
                 <img src={value.taskIcon} className="h-10" alt="" />
                 <p className="font-normal relative top-2 ml-4 text-link-blue-default hover:text-link-blue-hover">
-                  {t[value.task]}
+                  {value.task}
                 </p>
               </a>
             </li>

--- a/components/molecules/UniversalBenefitCard.js
+++ b/components/molecules/UniversalBenefitCard.js
@@ -37,9 +37,8 @@ export default function UniversalBenefitCard(props) {
   return (
     <div className="benefit-card pb-6" id={benefitCardId}>
       <StatusBadge
-        status={props.benefit.statusCode}
-        programCode={props.benefit.programCode}
-        locale={props.locale}
+        status={t[props.benefit.statusCode]}
+        program={t[props.benefit.programCode]}
       />
       <div className="px-4 md:px-6 pb-6">
         <div className="mx-auto sm:grid sm:grid-cols-4 sm:divide-x-2">

--- a/components/organisms/BenefitCard.js
+++ b/components/organisms/BenefitCard.js
@@ -1,0 +1,116 @@
+import propTypes from 'prop-types'
+import en from '../../locales/en'
+import fr from '../../locales/fr'
+import BenefitCardHeaderSummary from '../molecules/BenefitCardHeaderSummary'
+import StatusBadge from '../atoms/StatusBadge'
+import BenefitTasks from '../molecules/BenefitTasks'
+import HorizontalRule from '../atoms/HorizontalRule'
+import { useState } from 'react'
+import ViewMoreLessButton from '../atoms/ViewMoreLessButton'
+
+export default function BenefitCard(props) {
+  const t = en
+  const [isOpen, setIsOpen] = useState(false)
+  const benefitCardId = 'benefit-card-' + props.benefit.id
+  const taskListId = 'task-list-' + props.benefit.id
+
+  return (
+    <div className="benefit-card pb-6" id={benefitCardId}>
+      <StatusBadge
+        status={props.benefit.statusCode}
+        programCode={props.benefit.programCode}
+        locale={'en'}
+      />
+      <div className="px-4 md:px-6 pb-6">
+        <div className="mx-auto sm:grid sm:grid-cols-4 sm:divide-x-2">
+          <div className="col-span-1 py-4">
+            <h3 className="font-bold font-display text-4xl sm:text-lg md:text-xl lg:text-3xl xl:text-4xl mb-2">
+              {props.benefit.summary}
+            </h3>
+          </div>
+
+          <div className="grid col-span-3">
+            {props.benefit.summaries == null ||
+            props.benefit.summaries.length <= 0 ? (
+              <div className="mx-8">
+                <p className="pb-5 text-lg">{t.benefitDurationReached}</p>
+                <a
+                  href=""
+                  className="underline text-link-blue-default hover:text-link-blue-hover"
+                >
+                  <img
+                    src="/images/dashboard/apply-for-benefit-icon.svg"
+                    alt=""
+                  />
+                  <p className="w-36 sm:w-24 lg:w-36 pr-5 pt-3">
+                    {`${t.applyFor} ${t[props.benefit.programCode]}`}
+                  </p>
+                </a>
+              </div>
+            ) : (
+              <ul className="grid col-span-2 gap-y-4 gap-x-1 sm:grid-cols-3 sm:pl-8 lg:pl-10 font-display">
+                {props.benefit.summaries.map((summary, index) => {
+                  return (
+                    <BenefitCardHeaderSummary
+                      key={index}
+                      locale={'en'}
+                      summary={summary}
+                    />
+                  )
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+      <HorizontalRule width="w-auto sm:w-full" />
+      {/* Let the ViewMoreLessButton remain generic and set the heading level outside */}
+      <h4>
+        <ViewMoreLessButton
+          id={props.benefit.programCode + '-card-button'}
+          dataTestid={props.benefit.id}
+          onClick={() => {
+            const newOpenState = !isOpen
+            const idToScrollTo = newOpenState ? taskListId : benefitCardId
+            document.getElementById(idToScrollTo).scrollIntoView({
+              behavior: 'smooth',
+              block: 'start',
+            })
+            setIsOpen(newOpenState)
+          }}
+          ariaExpanded={isOpen.toString()}
+          icon={isOpen}
+          caption={t[props.benefit.taskHeadingKey]}
+        />
+      </h4>
+      <div className="flex flex-col">
+        {props.benefit.taskGroups == null ||
+        props.benefit.taskGroups.length <= 0 ? null : (
+          <div id={taskListId} className="grid bg-gray-lighter sm:grid-cols-1 ">
+            {!isOpen
+              ? null
+              : props.benefit.taskGroups.map((taskList, index) => {
+                  return (
+                    <div key={index}>
+                      <BenefitTasks taskList={taskList} locale={'en'} />
+                    </div>
+                  )
+                })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+BenefitCard.propTypes = {
+  benefit: propTypes.shape({
+    id: propTypes.string.isRequired,
+    code: propTypes.string.isRequired,
+    name: propTypes.string.isRequired,
+    summary: propTypes.string.isRequired,
+    statusCode: propTypes.string.isRequired,
+    summaries: propTypes.array,
+    taskGroups: propTypes.array.isRequired,
+    taskHeadingKey: propTypes.string.isRequired,
+  }),
+}

--- a/components/organisms/BenefitCard.js
+++ b/components/organisms/BenefitCard.js
@@ -14,9 +14,9 @@ export default function BenefitCard(props) {
   return (
     <div className="benefit-card pb-6" id={benefitCardId}>
       <StatusBadge
-        status={props.benefit.statusCode}
-        programCode={props.benefit.code}
-        locale={'en'}
+        status={props.benefit.status.text}
+        program={props.benefit.name}
+        className={props.benefit.status.className}
       />
       <div className="px-4 md:px-6 pb-6">
         <div className="mx-auto sm:grid sm:grid-cols-4 sm:divide-x-2">
@@ -105,7 +105,7 @@ BenefitCard.propTypes = {
     code: propTypes.string.isRequired,
     name: propTypes.string.isRequired,
     summary: propTypes.string.isRequired,
-    statusCode: propTypes.string.isRequired,
+    status: propTypes.string.isRequired,
     summaries: propTypes.array,
     taskGroups: propTypes.array.isRequired,
     moreLessCaption: propTypes.string.isRequired,

--- a/components/organisms/BenefitCard.js
+++ b/components/organisms/BenefitCard.js
@@ -84,7 +84,7 @@ export default function BenefitCard(props) {
               : props.benefit.taskGroups.map((taskList, index) => {
                   return (
                     <div key={index}>
-                      <BenefitTasks taskList={taskList} locale={'en'} />
+                      <BenefitTasks taskList={taskList} />
                     </div>
                   )
                 })}

--- a/components/organisms/BenefitCard.js
+++ b/components/organisms/BenefitCard.js
@@ -47,11 +47,7 @@ export default function BenefitCard(props) {
               <ul className="grid col-span-2 gap-y-4 gap-x-1 sm:grid-cols-3 sm:pl-8 lg:pl-10 font-display">
                 {props.benefit.summaries.map((summary, index) => {
                   return (
-                    <BenefitCardHeaderSummary
-                      key={index}
-                      locale={'en'}
-                      summary={summary}
-                    />
+                    <BenefitCardHeaderSummary key={index} summary={summary} />
                   )
                 })}
               </ul>

--- a/components/organisms/BenefitCard.js
+++ b/components/organisms/BenefitCard.js
@@ -1,6 +1,4 @@
 import propTypes from 'prop-types'
-import en from '../../locales/en'
-import fr from '../../locales/fr'
 import BenefitCardHeaderSummary from '../molecules/BenefitCardHeaderSummary'
 import StatusBadge from '../atoms/StatusBadge'
 import BenefitTasks from '../molecules/BenefitTasks'
@@ -9,7 +7,6 @@ import { useState } from 'react'
 import ViewMoreLessButton from '../atoms/ViewMoreLessButton'
 
 export default function BenefitCard(props) {
-  const t = en
   const [isOpen, setIsOpen] = useState(false)
   const benefitCardId = 'benefit-card-' + props.benefit.id
   const taskListId = 'task-list-' + props.benefit.id
@@ -18,7 +15,7 @@ export default function BenefitCard(props) {
     <div className="benefit-card pb-6" id={benefitCardId}>
       <StatusBadge
         status={props.benefit.statusCode}
-        programCode={props.benefit.programCode}
+        programCode={props.benefit.code}
         locale={'en'}
       />
       <div className="px-4 md:px-6 pb-6">
@@ -33,7 +30,7 @@ export default function BenefitCard(props) {
             {props.benefit.summaries == null ||
             props.benefit.summaries.length <= 0 ? (
               <div className="mx-8">
-                <p className="pb-5 text-lg">{t.benefitDurationReached}</p>
+                <p className="pb-5 text-lg">{props.benefitDurationReached}</p>
                 <a
                   href=""
                   className="underline text-link-blue-default hover:text-link-blue-hover"
@@ -43,7 +40,7 @@ export default function BenefitCard(props) {
                     alt=""
                   />
                   <p className="w-36 sm:w-24 lg:w-36 pr-5 pt-3">
-                    {`${t.applyFor} ${t[props.benefit.programCode]}`}
+                    {`${props.applyFor} ${props.benefit.name}`}
                   </p>
                 </a>
               </div>
@@ -67,7 +64,7 @@ export default function BenefitCard(props) {
       {/* Let the ViewMoreLessButton remain generic and set the heading level outside */}
       <h4>
         <ViewMoreLessButton
-          id={props.benefit.programCode + '-card-button'}
+          id={props.benefit.code + '-card-button'}
           dataTestid={props.benefit.id}
           onClick={() => {
             const newOpenState = !isOpen
@@ -80,7 +77,7 @@ export default function BenefitCard(props) {
           }}
           ariaExpanded={isOpen.toString()}
           icon={isOpen}
-          caption={t[props.benefit.taskHeadingKey]}
+          caption={props.benefit.moreLessCaption}
         />
       </h4>
       <div className="flex flex-col">
@@ -111,6 +108,8 @@ BenefitCard.propTypes = {
     statusCode: propTypes.string.isRequired,
     summaries: propTypes.array,
     taskGroups: propTypes.array.isRequired,
-    taskHeadingKey: propTypes.string.isRequired,
+    moreLessCaption: propTypes.string.isRequired,
   }),
+  benefitDurationReached: propTypes.string.isRequired,
+  applyFor: propTypes.string.isRequired,
 }

--- a/components/organisms/BenefitCard.js
+++ b/components/organisms/BenefitCard.js
@@ -15,7 +15,6 @@ export default function BenefitCard(props) {
     <div className="benefit-card pb-6" id={benefitCardId}>
       <StatusBadge
         status={props.benefit.status.text}
-        program={props.benefit.name}
         className={props.benefit.status.className}
       />
       <div className="px-4 md:px-6 pb-6">

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -77,13 +77,13 @@ export default function Dashboard(props) {
     summary:
       props.locale === 'en' ? (
         <>
-          {t[props.benefit.programCode]}
+          {t.cpp}
           <span className="sr-only">{t.summary}</span>
         </>
       ) : (
         <>
           <span className="sr-only">{t.summary}</span>
-          {t[props.benefit.programCode]}
+          {t.cpp}
         </>
       ),
     statusCode: 'inPayment',
@@ -164,14 +164,18 @@ export default function Dashboard(props) {
         ],
       },
     ],
-    taskHeadingKey: 'paymentsTaxesAccount',
+    moreLessCaption: t['paymentsTaxesAccount'],
   }
 
   return (
     <>
       <Greeting locale={props.locale} name="Mary" />
 
-      <BenefitCard benefit={cppBenefitCard} />
+      <BenefitCard
+        benefit={cppBenefitCard}
+        benefitDurationReached={t.benefitDurationReached}
+        applyFor={t.applyFor}
+      />
 
       <div className="mb-8">
         {cppLoaded ? null : 'Loading CPP User Benefit Data...'}

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -86,7 +86,7 @@ export default function Dashboard(props) {
           {t.cpp}
         </>
       ),
-    statusCode: 'inPayment',
+    status: { text: t['inPayment'], className: 'bg-status-inPayment' },
     typeCode: 'CPPRetirement',
     summaries: [
       {

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -127,58 +127,58 @@ export default function Dashboard(props) {
     ],
     taskGroups: [
       {
-        header: 'paymentTasks',
+        header: t.paymentTasks,
         tasks: [
           {
-            task: 'allPaymentsTask',
+            task: t.allPaymentsTask,
             taskIcon: '/images/dashboard/oas-payment-icon.svg',
-            taskLink: 'allPaymentsTaskLink',
+            taskLink: t.allPaymentsTaskLink,
           },
           {
-            task: 'taxSlipTask',
+            task: t.taxSlipTask,
             taskIcon: '/images/dashboard/oas-tax-slip-icon.svg',
-            taskLink: 'taxSlipTaskLink',
+            taskLink: t.taxSlipTaskLink,
           },
           {
-            task: 'cppContributionTask',
+            task: t.cppContributionTask,
             taskIcon: '/images/dashboard/oas-cpp-contributions-icon.svg',
-            taskLink: 'cppContributionTaskLink',
+            taskLink: t.cppContributionTaskLink,
           },
           {
-            task: 'taxDeductionsTask',
+            task: t.taxDeductionsTask,
             taskIcon: '/images/dashboard/oas-federal-tax-deductions-icon.svg',
-            taskLink: 'taxDeductionsTaskLink',
+            taskLink: t.taxDeductionsTaskLink,
           },
           {
-            task: 'retirementIncomeTask',
+            task: t.retirementIncomeTask,
             taskIcon: '/images/dashboard/oas-retirement-income-icon.svg',
-            taskLink: 'retirementIncomeTaskLink',
+            taskLink: t.retirementIncomeTaskLink,
           },
         ],
       },
       {
-        header: 'changeTasks',
+        header: t.changeTasks,
         tasks: [
           {
-            task: 'reconsiderationTask',
+            task: t.reconsiderationTask,
             taskIcon:
               '/images/dashboard/oas-request-for-reconsideration-icon.svg ',
-            taskLink: 'reconsiderationLink',
+            taskLink: t.reconsiderationLink,
           },
           {
-            task: 'delayOasPensionTask',
+            task: t.delayOasPensionTask,
             taskIcon: '/images/dashboard/oas-delay-receiving-pension-icon.svg',
-            taskLink: 'delayOasPensionTaskLink',
+            taskLink: t.delayOasPensionTaskLink,
           },
           {
-            task: 'giveConsentTask',
+            task: t.giveConsentTask,
             taskIcon: '/images/dashboard/oas-consent-icon.svg',
-            taskLink: 'giveConsentTaskLink',
+            taskLink: t.giveConsentTaskLink,
           },
           {
-            task: 'updateAccountInfoTask',
+            task: t.updateAccountInfoTask,
             taskIcon: '/images/dashboard/account-info-icon.svg',
-            taskLink: 'updateAccountInfoTaskLink',
+            taskLink: t.updateAccountInfoTaskLink,
           },
         ],
       },
@@ -197,7 +197,7 @@ export default function Dashboard(props) {
       />
 
       <div className="mb-8">
-        {cppLoaded ? null : 'Loading CPP User Benefit Data...'}
+        {/* {cppLoaded ? null : 'Loading CPP User Benefit Data...'}
         {cppError ?? null}
         {cppBenefit
           ? cppBenefit.map((value, index) => {
@@ -271,7 +271,7 @@ export default function Dashboard(props) {
         {sebError}
         {sebBenefit ? (
           <UniversalBenefitCard locale={props.locale} benefit={sebBenefit} />
-        ) : null}
+        ) : null} */}
 
         {/* application or "advertising" cards */}
         {advertisingCards.map((value, index) => {

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -7,8 +7,12 @@ import { getSession } from 'next-auth/react'
 import UniversalBenefitCard from '../components/molecules/UniversalBenefitCard'
 import { useEffect, useState } from 'react'
 import { setCookies } from 'cookies-next'
+import BenefitCard from '../components/organisms/BenefitCard'
+import en from '../locales/en'
+import fr from '../locales/fr'
 
 export default function Dashboard(props) {
+  const t = props.locale === 'en' ? en : fr
   const [advertisingCards, setAdvertisingCards] = useState(
     props.advertisingCards
   )
@@ -100,9 +104,109 @@ export default function Dashboard(props) {
       .finally(() => setSebLoaded(true))
   }, [])
 
+  let cppBenefitCard = {
+    id: 'cpp-CPPRetirement-inPayment',
+    code: 'cpp',
+    name: t.cpp,
+    summary:
+      props.locale === 'en' ? (
+        <>
+          {t[props.benefit.programCode]}
+          <span className="sr-only">{t.summary}</span>
+        </>
+      ) : (
+        <>
+          <span className="sr-only">{t.summary}</span>
+          {t[props.benefit.programCode]}
+        </>
+      ),
+    statusCode: 'inPayment',
+    typeCode: 'CPPRetirement',
+    summaries: [
+      {
+        type: 'ActiveBenefit',
+        value: 'CPPRetirement',
+      },
+      {
+        type: 'LastPaymentDate',
+        value: '2021-02-21',
+      },
+      {
+        type: 'NextPayment',
+        value: 1616281200000,
+      },
+      {
+        type: 'LastPayment',
+        value: 30.32,
+      },
+    ],
+    taskGroups: [
+      {
+        header: 'paymentTasks',
+        tasks: [
+          {
+            task: 'allPaymentsTask',
+            taskIcon: '/images/dashboard/oas-payment-icon.svg',
+            taskLink: 'allPaymentsTaskLink',
+          },
+          {
+            task: 'taxSlipTask',
+            taskIcon: '/images/dashboard/oas-tax-slip-icon.svg',
+            taskLink: 'taxSlipTaskLink',
+          },
+          {
+            task: 'cppContributionTask',
+            taskIcon: '/images/dashboard/oas-cpp-contributions-icon.svg',
+            taskLink: 'cppContributionTaskLink',
+          },
+          {
+            task: 'taxDeductionsTask',
+            taskIcon: '/images/dashboard/oas-federal-tax-deductions-icon.svg',
+            taskLink: 'taxDeductionsTaskLink',
+          },
+          {
+            task: 'retirementIncomeTask',
+            taskIcon: '/images/dashboard/oas-retirement-income-icon.svg',
+            taskLink: 'retirementIncomeTaskLink',
+          },
+        ],
+      },
+      {
+        header: 'changeTasks',
+        tasks: [
+          {
+            task: 'reconsiderationTask',
+            taskIcon:
+              '/images/dashboard/oas-request-for-reconsideration-icon.svg ',
+            taskLink: 'reconsiderationLink',
+          },
+          {
+            task: 'delayOasPensionTask',
+            taskIcon: '/images/dashboard/oas-delay-receiving-pension-icon.svg',
+            taskLink: 'delayOasPensionTaskLink',
+          },
+          {
+            task: 'giveConsentTask',
+            taskIcon: '/images/dashboard/oas-consent-icon.svg',
+            taskLink: 'giveConsentTaskLink',
+          },
+          {
+            task: 'updateAccountInfoTask',
+            taskIcon: '/images/dashboard/account-info-icon.svg',
+            taskLink: 'updateAccountInfoTaskLink',
+          },
+        ],
+      },
+    ],
+    taskHeadingKey: 'paymentsTaxesAccount',
+  }
+
   return (
     <>
       <Greeting locale={props.locale} name="Mary" />
+
+      <BenefitCard benefit={cppBenefitCard} />
+
       <div className="mb-8">
         {cppLoaded ? null : 'Loading User Benefit Data...'}
         {cppBenefit

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -86,7 +86,15 @@ export default function Dashboard(props) {
           {t.cpp}
         </>
       ),
-    status: { text: t['inPayment'], className: 'bg-status-inPayment' },
+    status: {
+      text: (
+        <>
+          <span className="sr-only">{props.program} </span>
+          {t['inPayment']}
+        </>
+      ),
+      className: 'bg-status-inPayment',
+    },
     typeCode: 'CPPRetirement',
     summaries: [
       {

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -10,6 +10,7 @@ import { setCookies } from 'cookies-next'
 import BenefitCard from '../components/organisms/BenefitCard'
 import en from '../locales/en'
 import fr from '../locales/fr'
+import { formatDate, formatMoney } from '../lib/Utils'
 
 export default function Dashboard(props) {
   const t = props.locale === 'en' ? en : fr
@@ -99,19 +100,29 @@ export default function Dashboard(props) {
     summaries: [
       {
         type: 'ActiveBenefit',
+        title: t.ActiveBenefit.title,
         value: 'CPPRetirement',
+        valueClassName: 'text-lg',
       },
       {
         type: 'LastPaymentDate',
-        value: '2021-02-21',
+        title: t.LastPaymentDate.title,
+        value: formatDate('2021-02-21', props.locale),
+        valueClassName: 'text-lg',
+        link: '/',
+        linkText: 'View my payments',
       },
       {
         type: 'NextPayment',
-        value: 1616281200000,
+        title: t.NextPayment.title,
+        value: formatDate(1616281200000, props.locale),
+        valueClassName: 'text-lg',
       },
       {
         type: 'LastPayment',
-        value: 30.32,
+        title: t.LastPayment.title,
+        value: formatMoney(30.32, props.locale),
+        valueClassName: 'text-3xl',
       },
     ],
     taskGroups: [


### PR DESCRIPTION
## Reworked benefit card to not be dependant on language or business logic

### Description
Removed locale/lang from card components, removed business logic from card components and renamed component.
This is to allow for the reuse of components and ability to control text/look from API responses.

This PR needs an initial review before working on the API requests as it has big impacts throughout the app

List of proposed changes:
- Locale is no longer used within components for reuse and AEM compatibility
- Business logic is removed from components for reuse and best practice standards

### What to test for/How to test
Ensure card component is visually and functionally the same

### Additional Notes
API calls require more work to form the expected response for these changes