### PR TITLE
adding InfoSection for Profile and Security pages

### DIFF
--- a/components/atoms/InfoSection.js
+++ b/components/atoms/InfoSection.js
@@ -1,0 +1,38 @@
+import propTypes from 'prop-types'
+import Link from 'next/link'
+
+export default function InfoSection(props) {
+  return (
+    <>
+      <h3 className="mt-14 pb-6 font-bold text-3xl">{props.title}</h3>
+      {props.info.map((item, index) => {
+        return (
+          <p key={index} className="text-lg">
+            {item}
+          </p>
+        )
+      })}
+      <Link href={props.editLink} passHref>
+        <a className="inline-block mt-4 p-2.5 shadow-sm shadow-gray-darker rounded bg-gray-light text-blue-default hover:bg-grey-medium hover:text-blue-hover hover:cursor-pointer focus:shadow-none">
+          {props.editText}
+        </a>
+      </Link>
+    </>
+  )
+}
+
+InfoSection.propTypes = {
+  /*
+   *  Section Title
+   */
+  title: propTypes.string.isRequired,
+  /*
+   *  Information
+   */
+  info: propTypes.arrayOf(propTypes.string).isRequired,
+  /**
+   * link to edit the info
+   */
+  editLink: propTypes.string,
+  editText: propTypes.string,
+}

--- a/components/atoms/InfoSection.test.js
+++ b/components/atoms/InfoSection.test.js
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import InfoSection from './InfoSection'
+
+expect.extend(toHaveNoViolations)
+
+describe('InfoSection', () => {
+  const { container } = render(
+    <InfoSection
+      title="title"
+      info={['info1', 'other info']}
+      editLink="link"
+      editText="text"
+    />
+  )
+
+  it('renders ProfileInfoSection', () => {
+    const text1 = screen.getByText('title')
+    const text2 = screen.getByText('info1')
+    expect(text1).toBeInTheDocument()
+    expect(text2).toBeInTheDocument()
+  })
+
+  it('has no a11y violations', async () => {
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "cookies-next": "^2.0.4",
         "jest-axe": "^5.0.1",
-        "next": "^12.1.6",
+        "next": "12.1.6",
         "next-auth": "^4.5.0",
         "prom-client": "^12.0.0",
         "prop-types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "cookies-next": "^2.0.4",
     "jest-axe": "^5.0.1",
-    "next": "^12.1.6",
+    "next": "12.1.6",
     "next-auth": "^4.5.0",
     "prom-client": "^12.0.0",
     "prop-types": "^15.8.1",

--- a/pages/security-settings.js
+++ b/pages/security-settings.js
@@ -1,0 +1,25 @@
+import InfoSection from '../components/atoms/InfoSection'
+
+export function getStaticProps() {
+  const metadata = {
+    title: 'Digital Centre (en) + Digital Centre (fr)',
+    keywords: 'en + fr keywords',
+    description: 'en + fr description',
+  }
+  return { props: { metadata } }
+}
+
+export default function SecuritySettings() {
+  return (
+    <>
+      <h1>Security Settings</h1>
+      <h2>Update your security settings</h2>
+      <InfoSection
+        title="Multi-factor authentication"
+        info={['Modify multi-factor authentication settings']}
+        editText="Edit"
+        editLink="/"
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## [DCWC-1985](https://jira-dev.bdm-dev.dts-stn.com/browse/DCWC-1985) (Jira Issue)

### Description

List of proposed changes:

- Adds a new component `InfoSection` based of of the `ProfileInfoSection`
- Adds a skeleton Security page to test it on

### What to test for/How to test

look a the ../security-settings page

### Additional Notes

The page will get updated later, and might not even call this component directly, just in place to test it.
