### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    pull-request-branch-name:
+      separator: "-"


### PR DESCRIPTION
### Description

List of proposed changes:

- Adding a dependabot config to change the branch separator to `-`.
  - This is in hopes that it would get the branch deployments to work but the names might still be too long.

### What to test for/How to test

We'll probably just have to wait for the bot to flag and open a PR.
