### PR TITLE
Bug fix: client match server

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -8,7 +8,7 @@ import {
 } from '../contents/BenefitAdvertisingCards'
 import UniversalBenefitCard from '../components/molecules/UniversalBenefitCard'
 import { useEffect, useState } from 'react'
-import { getCookie, setCookie } from 'cookies-next'
+import { setCookie } from 'cookies-next'
 import { TASK_GROUPS } from '../contents/BenefitTasksGroups'
 import en from '../locales/en'
 import fr from '../locales/fr'

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -25,7 +25,6 @@ import LoadingState from '../components/molecules/LoadingState'
 export default function Dashboard(props) {
   const t = props.locale === 'en' ? en : fr
   let time = new Date().getHours()
-  const userid = getCookie('userid')
 
   const [advertisingCards, setAdvertisingCards] = useState(
     props.advertisingCards
@@ -269,16 +268,13 @@ export default function Dashboard(props) {
           )
         })}
 
-        {/* no benefit cards display only on the "all cards" page */}
-        {userid == 'default'
-          ? noBenefitCards.map((value, index) => {
-              return (
-                <div key={index} data-testid={'no-benefit-card' + index}>
-                  <NoBenefitCard locale={props.locale} benefit={value} />
-                </div>
-              )
-            })
-          : null}
+        {noBenefitCards.map((value, index) => {
+          return (
+            <div key={index} data-testid={'no-benefit-card' + index}>
+              <NoBenefitCard locale={props.locale} benefit={value} />
+            </div>
+          )
+        })}
       </div>
     </>
   )
@@ -301,10 +297,13 @@ export async function getServerSideProps({ req, res, locale, query }) {
     description: 'en + fr description',
   }
 
+  //no benefit cards display only on the "all cards" page
+  const noBenefitCards = userid === 'default' ? getNoBenefitCards(locale) : []
+
   return {
     props: {
       advertisingCards: getAdvertisingCards(),
-      noBenefitCards: getNoBenefitCards(locale),
+      noBenefitCards,
       isAuth: true,
       locale,
       metadata,


### PR DESCRIPTION
## Description of Changes
An warning occurred due to filtering no benefit cards without using useEffect

### What to test for/How to test
Open the console for /dashboard?userid=default
The console should no longer warn about div mismatches between server and client