### PR TITLE
Adding a step to truncate build names

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -316,17 +316,17 @@ object Build_Dynamic: BuildType({
     }
    
     steps {
-        powershell {
+        script {
             name = "Create custom branch name"
             scriptContent = """
-                $buildName = "%teamcity.build.branch%"
-                try {
-                    (GC $buildName).Replace("dependabot-npm_and_yarn", "dp-").Replace("-.*_(\d+(\.\d+){1,3}).*", "").subString(0,100) | Set-Content $buildName
-                    Write-Output $buildName
-                } catch [System.Exception] {
-                    Write-Output $_
-                    Exit 1
-                }
+                branchName="%env.BRANCH%"
+                branchName=${branchName/dependabot/dp}
+                branchName=${branchName/-npm_and_yarn/}
+                branchName=${branchName/-github_actions/}
+                branchName=${branchName//./}
+                branchName=${branchName:0:27}
+                branchName=${branchName%-}
+                ##teamcity[setParameter name='env.BRANCH' value='${branchName}']
             """.trimIndent()
         }
         dockerCommand {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -316,6 +316,19 @@ object Build_Dynamic: BuildType({
     }
    
     steps {
+        powershell {
+            name = "Create custom branch name"
+            scriptContent = """
+                $buildName = "%teamcity.build.branch%"
+                try {
+                    (GC $buildName).Replace("dependabot-npm_and_yarn", "dp-").Replace("-.*_(\d+(\.\d+){1,3}).*", "").subString(0,100) | Set-Content $buildName
+                    Write-Output $buildName
+                } catch [System.Exception] {
+                    Write-Output $_
+                    Exit 1
+                }
+            """.trimIndent()
+        }
         dockerCommand {
             name = "Build & Tag Docker Image"
             commandType = build {


### PR DESCRIPTION
## Description of Changes

### [ADO Work Item 65286](https://dev.azure.com/VP-BD/DECD/_workitems/edit/65286)

Adding a step to dynamic build to truncate the build name so that deployments don't fail for a bad formatted name based on the branch.

### What to test for/How to test

### Additional Notes

## Checklist

- [ ] Tests added for key features and bugs
- [ ] Deployment working
