### PR TITLE
Fix error thrown by access_token being null

### DIFF
--- a/lib/api/programData.js
+++ b/lib/api/programData.js
@@ -26,7 +26,7 @@ export async function FetchProgramData(
       if (!AuthIsDisabled() && !(await AuthIsValid(req)))
         return res.status(401).end('Authentication Required')
       try {
-        const accessToken = (await getToken({ req })).access_token
+        const accessToken = (await getToken({ req }))?.access_token
         let result
         let userid
         if (getMockData) {


### PR DESCRIPTION
## Description of Changes
Added optional chaining when attempting to get the access token, which should prevent run-time errors.   

### No ADO Work Item

### What to test for/How to test

### Additional Notes

## Checklist

- [ ] Tests added for key features and bugs
- [ ] Deployment working
