### PR TITLE
Update ref for test coverage deploys

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -3,20 +3,20 @@
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/sc-digital-centre/End-To-End%20Tests/dev?label=End-To-End%20Tests)](https://dts-stn.github.io/sc-digital-centre/dev/coverage/e2e-report)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/sc-digital-centre/Unit%20Checks/dev?label=Lint%20and%20Unit%20Checks)](https://dts-stn.github.io/sc-digital-centre/dev/coverage/lcov-report)
 
-![Line Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Line%20Coverage&query=%24.total.lines.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Fdev%2Fcoverage%2Fcoverage-summary.json)
-![Statements Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Statement%20Coverage&query=%24.total.statements.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Fdev%2Fcoverage%2Fcoverage-summary.json)
-![Function Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Function%20coverage&query=%24.total.functions.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Fdev%2Fcoverage%2Fcoverage-summary.json)
-![Branch Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Branch%20coverage&query=%24.total.branches.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Fdev%2Fcoverage%2Fcoverage-summary.json)
+![Line Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Line%20Coverage&query=%24.total.lines.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Frefs%2Fheads%2Fdev%2Fcoverage%2Fcoverage-summary.json)
+![Statements Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Statement%20Coverage&query=%24.total.statements.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Frefs%2Fheads%2Fdev%2Fcoverage%2Fcoverage-summary.json)
+![Function Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Function%20coverage&query=%24.total.functions.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Frefs%2Fheads%2Fdev%2Fcoverage%2Fcoverage-summary.json)
+![Branch Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Branch%20coverage&query=%24.total.branches.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Frefs%2Fheads%2Fdev%2Fcoverage%2Fcoverage-summary.json)
 
-# Click to view the test reports for MAIN 🔬📊
+# Click to view the test reports for MAIN 🔬 📊
 
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/sc-digital-centre/End-To-End%20Tests/main?label=End-To-End%20Tests)](https://dts-stn.github.io/sc-digital-centre/main/coverage/e2e-report)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/sc-digital-centre/Unit%20Checks/main?label=Lint%20and%20Unit%20Checks)](https://dts-stn.github.io/sc-digital-centre/main/coverage/lcov-report)
 
-![Line Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Line%20Coverage&query=%24.total.lines.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Fmain%2Fcoverage%2Fcoverage-summary.json)
-![Statements Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Statement%20Coverage&query=%24.total.statements.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Fmain%2Fcoverage%2Fcoverage-summary.json)
-![Function Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Function%20coverage&query=%24.total.functions.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Fmain%2Fcoverage%2Fcoverage-summary.json)
-![Branch Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Branch%20coverage&query=%24.total.branches.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Fmain%2Fcoverage%2Fcoverage-summary.json)
+![Line Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Line%20Coverage&query=%24.total.lines.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Frefs%2Fheads%2Fmain%2Fcoverage%2Fcoverage-summary.json)
+![Statements Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Statement%20Coverage&query=%24.total.statements.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Frefs%2Fheads%2Fmain%2Fcoverage%2Fcoverage-summary.json)
+![Function Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Function%20coverage&query=%24.total.functions.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Frefs%2Fheads%2Fmain%2Fcoverage%2Fcoverage-summary.json)
+![Branch Coverage Badge](https://img.shields.io/badge/dynamic/json?label=Branch%20coverage&query=%24.total.branches.pct&suffix=%25&url=https%3A%2F%2Fdts-stn.github.io%2Fsc-digital-centre%2Frefs%2Fheads%2Fmain%2Fcoverage%2Fcoverage-summary.json)
 
 ## Versions
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,5 +72,5 @@ jobs:
         if: ${{ github.actor != 'dependabot[bot]' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          target-folder: ${{ github.head_ref }}/e2e-report
+          target-folder: ${{ github.ref }}/e2e-report
           folder: report

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,6 +28,6 @@ jobs:
           edit-mode: replace
           body: |
             [Integration Deployment :rocket: ](https://sc-digital-centre-dyna-${{ github.head_ref }}.bdm-dev.dts-stn.com/dashboard) - [Check build status](https://teamcity.dts-stn.com/buildConfiguration/Dev_ScDigitalCentreProject_Build_Dynamic?branch=${{ github.head_ref }}&buildTypeTab=overview&mode=builds)
-            [Jest Coverage Report ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/${{ github.event.pull_request.base.repo.name }}/Unit%20Checks/${{ github.ref }}?label=Jest%20Test)](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/coverage/lcov-report/) 
-            [Cypress Coverage Report ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/${{ github.event.pull_request.base.repo.name }}/End-To-End%20Tests/${{ github.ref }}?label=E2E)](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/e2e-report/) 
+            [Jest Coverage Report ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/${{ github.event.pull_request.base.repo.name }}/Unit%20Checks/${{ github.ref_head }}?label=Jest%20Test)](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/coverage/lcov-report/) 
+            [Cypress Coverage Report ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/${{ github.event.pull_request.base.repo.name }}/End-To-End%20Tests/${{ github.ref_head }}?label=E2E)](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/e2e-report/) 
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,6 +28,6 @@ jobs:
           edit-mode: replace
           body: |
             [Integration Deployment :rocket: ](https://sc-digital-centre-dyna-${{ github.head_ref }}.bdm-dev.dts-stn.com/dashboard) - [Check build status](https://teamcity.dts-stn.com/buildConfiguration/Dev_ScDigitalCentreProject_Build_Dynamic?branch=${{ github.head_ref }}&buildTypeTab=overview&mode=builds)
-            [Jest Coverage Report ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/${{ github.event.pull_request.base.repo.name }}/Unit%20Checks/${{ github.head_ref }}?label=Jest%20Test)](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.head_ref }}/coverage/lcov-report/) 
-            [Cypress Coverage Report ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/${{ github.event.pull_request.base.repo.name }}/End-To-End%20Tests/${{ github.head_ref }}?label=E2E)](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.head_ref }}/e2e-report/) 
+            [Jest Coverage Report ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/${{ github.event.pull_request.base.repo.name }}/Unit%20Checks/${{ github.ref }}?label=Jest%20Test)](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/coverage/lcov-report/) 
+            [Cypress Coverage Report ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/${{ github.event.pull_request.base.repo.name }}/End-To-End%20Tests/${{ github.ref }}?label=E2E)](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/e2e-report/) 
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,6 +28,6 @@ jobs:
           edit-mode: replace
           body: |
             [Integration Deployment :rocket: ](https://sc-digital-centre-dyna-${{ github.head_ref }}.bdm-dev.dts-stn.com/dashboard) - [Check build status](https://teamcity.dts-stn.com/buildConfiguration/Dev_ScDigitalCentreProject_Build_Dynamic?branch=${{ github.head_ref }}&buildTypeTab=overview&mode=builds)
-            [Jest Coverage Report ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/${{ github.event.pull_request.base.repo.name }}/Unit%20Checks/${{ github.ref_head }}?label=Jest%20Test)](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/coverage/lcov-report/) 
-            [Cypress Coverage Report ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/${{ github.event.pull_request.base.repo.name }}/End-To-End%20Tests/${{ github.ref_head }}?label=E2E)](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/e2e-report/) 
+            [Jest Coverage Report ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/${{ github.event.pull_request.base.repo.name }}/Unit%20Checks/${{ github.head_ref }}?label=Jest%20Test)](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/coverage/lcov-report/) 
+            [Cypress Coverage Report ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DTS-STN/${{ github.event.pull_request.base.repo.name }}/End-To-End%20Tests/${{ github.head_ref }}?label=E2E)](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/e2e-report/) 
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -43,5 +43,5 @@ jobs:
         if: ${{ github.actor != 'dependabot[bot]' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          target-folder: ${{ github.head_ref }}/coverage
+          target-folder: ${{ github.ref }}/coverage
           folder: coverage


### PR DESCRIPTION
## Description of Changes

### [ADO Work Item 69487](https://dev.azure.com/VP-BD/DECD/_workitems/edit/69487)

Updating the reference for where test coverages are deployed in gh-pages

The head_ref was coming back empty when running on a "push" trigger (GitHub seems to have updated it)

### What to test for/How to test

All links work as expected (main won't until merged)

### Additional Notes

Will clean up the gh-pages branch.

## Checklist

- [ n/a] Tests added for key features and bugs
- [x] Deployment working
